### PR TITLE
feat: 하단 미니 플레이어 UI 구현

### DIFF
--- a/src/assets/svgs/CloseIcon.svg
+++ b/src/assets/svgs/CloseIcon.svg
@@ -1,0 +1,3 @@
+<svg width="46" height="46" viewBox="0 0 46 46" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M37.7775 10.944L35.0559 8.22241L23 20.2974L10.9441 8.22241L8.2225 10.944L20.2975 22.9999L8.2225 35.0558L10.9441 37.7774L23 25.7024L35.0559 37.7774L37.7775 35.0558L25.7025 22.9999L37.7775 10.944Z" fill="black"/>
+</svg>

--- a/src/assets/svgs/PauseIcon.svg
+++ b/src/assets/svgs/PauseIcon.svg
@@ -1,0 +1,3 @@
+<svg width="26" height="31" viewBox="0 0 26 31" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5.87712 29.2632H1.21045V1.26318H5.87712V29.2632ZM19.8771 1.26318H24.5438V29.2632H19.8771V1.26318Z" fill="black" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/svgs/PlayIcon.svg
+++ b/src/assets/svgs/PlayIcon.svg
@@ -1,0 +1,15 @@
+<svg width="38" height="38" viewBox="0 0 38 38" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_246_184)">
+<mask id="mask0_246_184" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="0" y="0" width="38" height="38">
+<path d="M0 0H38V38H0V0Z" fill="white"/>
+</mask>
+<g mask="url(#mask0_246_184)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M35.0455 24.1395C38.9999 21.8548 38.9999 16.1453 35.0455 13.8581L14.8461 2.18025C10.8894 -0.106871 5.9375 2.75025 5.9375 7.32213V30.6779C5.9375 35.2498 10.8894 38.1069 14.8461 35.8174L35.0455 24.1395Z" fill="black"/>
+</g>
+</g>
+<defs>
+<clipPath id="clip0_246_184">
+<rect width="38" height="38" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/components/MiniPlayer.jsx
+++ b/src/components/MiniPlayer.jsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+
+import CloseIcon from "@/assets/svgs/CloseIcon.svg?react";
+import PauseIcon from "@/assets/svgs/PauseIcon.svg?react";
+import PlayIcon from "@/assets/svgs/PlayIcon.svg?react";
+
+const MiniPlayer = ({ thumbnail, channelName, closePlayer }) => {
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  const handlePlayPause = () => {
+    setIsPlaying((prev) => !prev);
+  };
+
+  return (
+    <div className="flex h-20 w-[390px] justify-between rounded-b-4xl bg-white px-4 shadow-[0_-6px_9px_rgba(0,0,0,0.3)]">
+      <div className="flex items-center">
+        <img
+          className="ml-2 h-16 w-16"
+          src={thumbnail}
+          alt={`${channelName} 썸네일`}
+        />
+        <p className="ml-2 text-sm font-black">{channelName}</p>
+      </div>
+      <div className="flex items-center gap-3">
+        {!isPlaying ? (
+          <PlayIcon
+            className="h-9 w-9 cursor-pointer"
+            onClick={handlePlayPause}
+          />
+        ) : (
+          <PauseIcon className="cursor-pointer" onClick={handlePlayPause} />
+        )}
+        <CloseIcon className="cursor-pointer" onClick={closePlayer} />
+      </div>
+    </div>
+  );
+};
+
+export default MiniPlayer;

--- a/src/components/MiniPlayer.jsx
+++ b/src/components/MiniPlayer.jsx
@@ -12,7 +12,7 @@ const MiniPlayer = ({ thumbnail, channelName, closePlayer }) => {
   };
 
   return (
-    <div className="flex h-20 w-[390px] justify-between rounded-b-4xl bg-white px-4 shadow-[0_-6px_9px_rgba(0,0,0,0.3)]">
+    <div className="flex h-20 w-full justify-between rounded-b-4xl bg-white px-4 shadow-[0_-6px_9px_rgba(0,0,0,0.3)]">
       <div className="flex items-center">
         <img
           className="ml-2 h-16 w-16"


### PR DESCRIPTION
### ✨ 이슈 번호 

- #10 

### 📌 설명

- 하단 미니 플레이어 UI 컴포넌트를 구현한 PR입니다.
- 채널 정보, 재생/일시 정지 버튼, 플레이어 닫기 버튼을 포함합니다.

### 📃 작업 사항 

- [X] 현재 재생 중인 채널 정보 표시 UI 구현
- [X] 재생 버튼(▶️) 클릭 시 일시 정지 버튼(⏸️)으로 전환되도록 처리
- [X] 일시 정지 버튼(⏸️) 클릭 시 재생 버튼(▶️)으로 전환되도록 처리
- [X] 닫기 버튼(❌) 클릭 시 미니 플레이어 닫힘 기능 구현
- [X] 상단 영역 음영 효과 적용

### 💡 참고 사항 

https://github.com/user-attachments/assets/49d3ae74-b7da-40a1-aed4-1d8e160a309c

### 💭 리뷰 사항 반영 

- [X] MiniPlayer 너비 full로 변경

### ✅ Pull Request 체크 사항

- [X] 가장 최신 브랜치를 pull 하였습니다.
- [X] base 브랜치명을 확인하였습니다.
- [X] 코드 컨벤션을 모두 확인하였습니다.
- [X] 브랜치명을 확인하였습니다.
