### PR TITLE
feat: 설정 화면 페이지 UI 구현

### DIFF
--- a/src/components/SettingListItem.jsx
+++ b/src/components/SettingListItem.jsx
@@ -1,0 +1,25 @@
+import ToggleButton from "@/components/ToggleButton";
+
+const SettingListItem = ({ title, explanations }) => {
+  return (
+    <li className="my-4 flex h-[100px] w-full min-w-80 rounded-md bg-gray-100 px-4 pt-4">
+      <div className="w-[272px]">
+        <h2 className="text-lg font-semibold">{title}</h2>
+        {explanations.map((explanation, index) =>
+          index === 0 ? (
+            <p className="mt-1 mb-[-4px] text-[14px] text-[#888888]">
+              {explanation}
+            </p>
+          ) : (
+            <p className="text-[14px] text-[#888888]">{explanation}</p>
+          )
+        )}
+      </div>
+      <div className="my-auto ml-auto">
+        <ToggleButton />
+      </div>
+    </li>
+  );
+};
+
+export default SettingListItem;

--- a/src/components/TabBar.jsx
+++ b/src/components/TabBar.jsx
@@ -9,7 +9,7 @@ const TabBar = () => {
   ];
 
   return (
-    <div className="mt-5 flex bg-white px-4 text-black">
+    <div className="mt-5 flex bg-white text-black">
       {tabItems.map(({ key, label }) => (
         <div
           key={key}

--- a/src/components/ToggleButton.jsx
+++ b/src/components/ToggleButton.jsx
@@ -10,13 +10,13 @@ const ToggleButton = () => {
   return (
     <>
       <button
-        className={`relative h-9 w-17 cursor-pointer rounded-full transition-colors duration-200 ${
+        className={`relative h-8 w-15 cursor-pointer rounded-full transition-colors duration-200 ${
           isActive ? "bg-black" : "bg-neutral-300"
         }`}
         onClick={handleToggle}
       >
         <div
-          className={`absolute top-1 left-1 h-7 w-7 rounded-full bg-white duration-400 ${
+          className={`absolute top-1 left-1 h-6 w-6 rounded-full bg-white duration-400 ${
             isActive ? "translate-x-8" : "translate-x-0"
           }`}
         />

--- a/src/components/ToggleButton.jsx
+++ b/src/components/ToggleButton.jsx
@@ -10,7 +10,7 @@ const ToggleButton = () => {
   return (
     <>
       <button
-        className={`relative h-8 w-15 cursor-pointer rounded-full transition-colors duration-200 ${
+        className={`relative h-8 w-16 cursor-pointer rounded-full transition-colors duration-200 ${
           isActive ? "bg-black" : "bg-neutral-300"
         }`}
         onClick={handleToggle}

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -11,7 +11,7 @@ const settingList = [
     ],
   },
   {
-    type: "isAdDetect",
+    type: "isReturnChannel",
     title: "기존 채널로 이동",
     explanations: ["이전 채널의 광고가 종료되면", "자동으로 복귀합니다."],
   },

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -1,5 +1,42 @@
+import TabBar from "@/components/TabBar";
+import ToggleButton from "@/components/ToggleButton";
+
 const Settings = () => {
-  return <>Settings</>;
+  return (
+    <>
+      <TabBar />
+      <div className="p-4">
+        <ul>
+          <li className="my-4 flex h-[88px] w-full min-w-80 rounded-md bg-gray-100 p-2">
+            <section className="w-72">
+              <strong className="text-lg">광고 감지</strong>
+              <p className="mb-[-4px] text-[#888888]">
+                현재 채널에서 광고를 자동으로 감지합니다.
+              </p>
+              <p className="text-[#888888]">
+                광고가 감지되면 다른 채널로 이동합니다.
+              </p>
+            </section>
+            <section className="mx-auto my-auto">
+              <ToggleButton />
+            </section>
+          </li>
+          <li className="my-4 flex h-[88px] w-full min-w-80 rounded-md bg-gray-100 p-2">
+            <section className="w-72">
+              <strong className="text-lg">기존 채널로 이동</strong>
+              <p className="mb-[-4px] text-[#888888]">
+                이전 채널의 광고가 종료되면
+              </p>
+              <p className="text-[#888888]">자동으로 복귀합니다.</p>
+            </section>
+            <section className="mx-auto my-auto">
+              <ToggleButton />
+            </section>
+          </li>
+        </ul>
+      </div>
+    </>
+  );
 };
 
 export default Settings;

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -1,5 +1,21 @@
+import SettingListItem from "@/components/SettingListItem";
 import TabBar from "@/components/TabBar";
-import ToggleButton from "@/components/ToggleButton";
+
+const settingList = [
+  {
+    type: "isAdDetect",
+    title: "광고 감지",
+    explanations: [
+      "현재 채널에서 광고를 자동으로 감지합니다.",
+      "광고가 감지되면 다른 채널로 이동합니다.",
+    ],
+  },
+  {
+    type: "isAdDetect",
+    title: "기존 채널로 이동",
+    explanations: ["이전 채널의 광고가 종료되면", "자동으로 복귀합니다."],
+  },
+];
 
 const Settings = () => {
   return (
@@ -7,32 +23,13 @@ const Settings = () => {
       <TabBar />
       <div className="p-4">
         <ul>
-          <li className="my-4 flex h-[88px] w-full min-w-80 rounded-md bg-gray-100 p-2">
-            <section className="w-72">
-              <strong className="text-lg">광고 감지</strong>
-              <p className="mb-[-4px] text-[#888888]">
-                현재 채널에서 광고를 자동으로 감지합니다.
-              </p>
-              <p className="text-[#888888]">
-                광고가 감지되면 다른 채널로 이동합니다.
-              </p>
-            </section>
-            <section className="mx-auto my-auto">
-              <ToggleButton />
-            </section>
-          </li>
-          <li className="my-4 flex h-[88px] w-full min-w-80 rounded-md bg-gray-100 p-2">
-            <section className="w-72">
-              <strong className="text-lg">기존 채널로 이동</strong>
-              <p className="mb-[-4px] text-[#888888]">
-                이전 채널의 광고가 종료되면
-              </p>
-              <p className="text-[#888888]">자동으로 복귀합니다.</p>
-            </section>
-            <section className="mx-auto my-auto">
-              <ToggleButton />
-            </section>
-          </li>
+          {settingList.map(({ type, title, explanations }) => (
+            <SettingListItem
+              key={type}
+              title={title}
+              explanations={explanations}
+            />
+          ))}
         </ul>
       </div>
     </>


### PR DESCRIPTION
### ✨ 이슈 번호

- #13 

### 📌 설명

설정 페이지의 UI 작업을 진행한 Pull request입니다.

### 📃 작업 사항

- [x]  상단 설정 타이틀
- [x]  컨트롤러를 구성한다.
    - [x]  광고 감지 토글
    - [x]  기존 채널 이동 토글
- [x] TabBar 좌우 패딩 제거
- [x] ToggleButton 크기 축소

### 💡 참고 사항

설정 페이지 UI 구현을 진행하며 공용 컴포넌트인 TabBar와 ToggleButton에 수정사항이 생겼습니다.
TabBar에 빈 공간이 생겨 좌우 패딩을 제거함으로써 빈 공간을 제거했고, ToggleButton을 사용하며 생각보다 크다 판단했기에
@Eun0713 님과 상의하여 크기를 축소했습니다. 이 점 참고 부탁드립니다.

모바일 환경에서 UI는 아래와 같으며 최상단 흰 공간은 추후 작업할 header가 차지할 영역입니다.

![image](https://github.com/user-attachments/assets/921e687b-95bd-4510-b1dd-0309226bddb1)

### 💭 리뷰 사항 반영

- [x] 동일한 li 구조 SettingListitem 컴포넌트로 분리 및 리팩토링
- [x] section 태그 div로 변경
- [x] strong 태그 h2 태그로 변경
- [x] settingList에서 동일 타입 다른 타입으로 변경

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
