### PR TITLE
feat: 검색 화면 페이지 구현

### DIFF
--- a/src/components/ChannelListItem.jsx
+++ b/src/components/ChannelListItem.jsx
@@ -1,8 +1,15 @@
 import BlankStarIcon from "@/assets/svgs/icon-blank-star.svg?react";
 
-const ChannelListItem = ({ thumbnail, channelName, onToggleFavorite }) => {
+const ChannelListItem = ({
+  thumbnail,
+  channelName,
+  onToggleFavorite,
+  backgroundColor,
+}) => {
   return (
-    <li className="my-2 flex h-16 w-full items-center rounded-md bg-gray-100 p-2">
+    <li
+      className={`my-2 flex h-16 w-full items-center rounded-md ${backgroundColor} p-4`}
+    >
       <img
         className="h-12 w-12"
         src={thumbnail}
@@ -10,7 +17,7 @@ const ChannelListItem = ({ thumbnail, channelName, onToggleFavorite }) => {
       />
       <p className="ml-3 w-3/4 text-sm font-bold">{channelName}</p>
       <button onClick={onToggleFavorite}>
-        <BlankStarIcon className="mx-3 ml-auto" />
+        <BlankStarIcon className="ml-2" />
       </button>
     </li>
   );

--- a/src/components/header/RadioSearchInput.jsx
+++ b/src/components/header/RadioSearchInput.jsx
@@ -8,27 +8,25 @@ const RadioSearchInput = () => {
   const [isInputClicked, setIsInputClicked] = useState(false);
 
   return (
-    <div className="mt-10 ml-5 flex w-[348px] items-center gap-2">
-      <div className="flex h-11 flex-1 items-center rounded-4xl bg-neutral-200 px-4">
-        <SearchThinIcon className="mr-2" />
-        <input
-          onFocus={() => {
-            setIsInputClicked(true);
-          }}
-          onBlur={() => {
-            setIsInputClicked(false);
-          }}
-          type="text"
-          placeholder={isInputClicked ? " " : "Search by radio name"}
-          className="w-full text-sm font-semibold text-neutral-800 outline-none"
-        />
+    <div className="flex w-full justify-center pt-10">
+      <div className="flex w-full max-w-md items-center gap-2 px-4">
+        <div className="flex h-11 flex-1 items-center rounded-4xl bg-neutral-200 px-4">
+          <SearchThinIcon className="mr-2" />
+          <input
+            onFocus={() => setIsInputClicked(true)}
+            onBlur={() => setIsInputClicked(false)}
+            type="text"
+            placeholder={isInputClicked ? " " : "Search by radio name"}
+            className="w-full text-sm font-semibold text-neutral-800 outline-none"
+          />
+        </div>
+        <button
+          className="cursor-pointer text-lg font-semibold text-neutral-500"
+          onClick={() => navigate(-1)}
+        >
+          취소
+        </button>
       </div>
-      <button
-        className="cursor-pointer text-lg font-semibold text-neutral-500"
-        onClick={() => navigate(-1)}
-      >
-        취소
-      </button>
     </div>
   );
 };

--- a/src/components/header/RadioSearchInput.jsx
+++ b/src/components/header/RadioSearchInput.jsx
@@ -16,7 +16,7 @@ const RadioSearchInput = () => {
             onFocus={() => setIsInputClicked(true)}
             onBlur={() => setIsInputClicked(false)}
             type="text"
-            placeholder={isInputClicked ? " " : "Search by radio name"}
+            placeholder={!isInputClicked && "Search by radio name"}
             className="w-full text-sm font-semibold text-neutral-800 outline-none"
           />
         </div>

--- a/src/pages/Search.jsx
+++ b/src/pages/Search.jsx
@@ -3,12 +3,9 @@ import RadioSearchInput from "@/components/header/RadioSearchInput";
 
 const Search = () => {
   return (
-    <>
-      <RadioSearchInput />
-      <div className="mt-8">
-        <ChannelListItem />
-      </div>
-    </>
+    <div className="mt-8">
+      <ChannelListItem />
+    </div>
   );
 };
 

--- a/src/pages/Search.jsx
+++ b/src/pages/Search.jsx
@@ -1,0 +1,15 @@
+import ChannelListItem from "@/components/ChannelListItem";
+import RadioSearchInput from "@/components/header/RadioSearchInput";
+
+const Search = () => {
+  return (
+    <>
+      <RadioSearchInput />
+      <div className="mt-8">
+        <ChannelListItem />
+      </div>
+    </>
+  );
+};
+
+export default Search;


### PR DESCRIPTION
### ✨ 이슈 번호 

- #22 

### 📌 설명 

- 검색 화면 페이지 구현에 관한 PR입니다.

### 📃 작업 사항

- [X] 메인 화면 우측 돋보기 아이콘 클릭 시 보이는 페이지
- [X] 라디오 썸네일 이미지, 제목, 즐겨찾기 아이콘을  포함
- [X] RadioSearchInput 반응형 스타일 개선

### 💡 참고 사항
![검색 화면](https://github.com/user-attachments/assets/5c074863-61bf-4556-b1a4-613c6d116537)

### 💭 리뷰 사항 반영

- [X] 불필요한 삼항 연산자 제거
- [X] 불필요한 Header 컴포넌트 및 fragment 제거

### ✅ Pull Request 체크 사항

- [X] 가장 최신 브랜치를 pull 하였습니다.
- [X] base 브랜치명을 확인하였습니다.
- [X] 코드 컨벤션을 모두 확인하였습니다.
- [X] 브랜치명을 확인하였습니다.
