### PR TITLE
feat: TabBar에서 Setting 탭 클릭 시 경로 이동 기능 추가

### DIFF
--- a/src/components/TabBar.jsx
+++ b/src/components/TabBar.jsx
@@ -17,11 +17,8 @@ const TabBar = () => {
         return (
           <div
             key={label}
-            className="w-full cursor-pointer text-center text-xl font-bold"
+            className={`w-full cursor-pointer text-center text-xl font-bold ${isActive ? "text-black" : "text-neutral-400"}`}
             onClick={() => navigate(path)}
-            style={{
-              color: isActive ? "black" : "gray",
-            }}
           >
             {label}
             {isActive && <div className="mt-3 h-1 rounded-xl bg-black" />}

--- a/src/components/TabBar.jsx
+++ b/src/components/TabBar.jsx
@@ -1,30 +1,35 @@
-import { useState } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
 
 const TabBar = () => {
-  const [activeTab, setActiveTab] = useState("home");
+  const navigate = useNavigate();
+  const location = useLocation();
 
   const tabItems = [
-    { key: "home", label: "Home" },
-    { key: "setting", label: "Setting" },
+    { label: "Home", path: "/" },
+    { label: "Setting", path: "/settings" },
   ];
 
   return (
     <div className="mt-5 flex bg-white text-black">
-      {tabItems.map(({ key, label }) => (
-        <div
-          key={key}
-          className="w-full cursor-pointer text-center text-xl font-bold"
-          onClick={() => setActiveTab(key)}
-          style={{
-            color: activeTab === key ? "black" : "gray",
-          }}
-        >
-          {label}
-          {activeTab === key && (
-            <div className="left-0 mt-3 h-1 rounded-[10px] bg-black" />
-          )}
-        </div>
-      ))}
+      {tabItems.map(({ label, path }) => {
+        const isActive = location.pathname === path;
+
+        return (
+          <div
+            key={label}
+            className="w-full cursor-pointer text-center text-xl font-bold"
+            onClick={() => navigate(path)}
+            style={{
+              color: isActive ? "black" : "gray",
+            }}
+          >
+            {label}
+            {isActive && (
+              <div className="left-0 mt-3 h-1 rounded-[10px] bg-black" />
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/src/components/TabBar.jsx
+++ b/src/components/TabBar.jsx
@@ -25,7 +25,7 @@ const TabBar = () => {
           >
             {label}
             {isActive && (
-              <div className="left-0 mt-3 h-1 rounded-[10px] bg-black" />
+              <div className="left-0 mt-3 h-1 rounded-xl bg-black" />
             )}
           </div>
         );

--- a/src/components/TabBar.jsx
+++ b/src/components/TabBar.jsx
@@ -24,9 +24,7 @@ const TabBar = () => {
             }}
           >
             {label}
-            {isActive && (
-              <div className="left-0 mt-3 h-1 rounded-xl bg-black" />
-            )}
+            {isActive && <div className="mt-3 h-1 rounded-xl bg-black" />}
           </div>
         );
       })}


### PR DESCRIPTION
### ✨ 이슈 번호

- #31 

### 📌 설명

- TabBar에 Setting 탭 클릭 시 `/settings`로 이동하는 기능을 추가한 PR입니다.
- useState를 사용하면 페이지 이동 후 강조 상태가 초기화되는 문제가 있어서  현재 경로를 기준으로 탭을 판단하도록 수정했습니다.

### 📃 작업 사항 

- [x] Setting 탭 클릭 시 `/settings`로 navigate 동작 구현
- [x] 탭 데이터를 label 과 path 로 변경
- [x] `useState` 제거 후 `useLocation` 로 탭 강조 처리하도록 변경

### 💡 참고 사항

https://github.com/user-attachments/assets/764497ca-daa8-463f-8ec0-91203aca5f12


### 💭 리뷰 사항 반영

- [x] 인라인 style 제거 및 조건부 Tailwind 클래스로 대체

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
