### PR TITLE
feat: 광고 탐지 라디오 이동 로직 구현

### DIFF
--- a/src/hooks/useAdKeywordsSocketListener.jsx
+++ b/src/hooks/useAdKeywordsSocketListener.jsx
@@ -1,34 +1,19 @@
-import { useCallback, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useEffect } from "react";
 
+import useChannelSwitchOnAd from "@/hooks/useChannelSwitchOnAd";
 import socket from "@/sockets/socketClient";
 
-const adKeywords = ["맥스", "SK브로드밴드", "대리운전"];
-
 const useAdKeywordsSocketListener = () => {
-  const navigate = useNavigate();
-
-  // TODO: 광고 키워드 조회 API 연동해서 adKeywords Mock Data를 응답값으로 변경
-  const checkAdKeywords = (text) => {
-    return adKeywords.some((adKeyword) => adKeyword.includes(text));
-  };
-
-  const handleRadioAdText = useCallback(
-    (text) => {
-      if (checkAdKeywords(text)) {
-        // TODO : 선호채널 목록 받아와서 /channel/:channelId 에 할당
-        navigate("/channel/2");
-      }
-    },
-    [navigate]
-  );
+  const handleChannelSwitch = useChannelSwitchOnAd();
 
   useEffect(() => {
     socket.on("connect", () => {
       console.log("connected");
     });
 
-    socket.on("radioText", handleRadioAdText);
+    socket.on("radioText", ({ isAd }) => {
+      handleChannelSwitch(isAd);
+    });
 
     socket.on("disconnect", () => {
       console.log("disconnect");
@@ -39,7 +24,7 @@ const useAdKeywordsSocketListener = () => {
       socket.off("radioText");
       socket.off("disconnect");
     };
-  }, [handleRadioAdText]);
+  }, [handleChannelSwitch]);
 };
 
 export default useAdKeywordsSocketListener;

--- a/src/hooks/useAdKeywordsSocketListener.jsx
+++ b/src/hooks/useAdKeywordsSocketListener.jsx
@@ -1,10 +1,10 @@
 import { useEffect } from "react";
 
-import useChannelSwitchOnAd from "@/hooks/useChannelSwitchOnAd";
+import useChannelSwitch from "@/hooks/useChannelSwitch";
 import socket from "@/sockets/socketClient";
 
 const useAdKeywordsSocketListener = () => {
-  const handleChannelSwitch = useChannelSwitchOnAd();
+  const handleChannelSwitch = useChannelSwitch();
 
   useEffect(() => {
     socket.on("connect", () => {

--- a/src/hooks/useChannelSwitch.jsx
+++ b/src/hooks/useChannelSwitch.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 
 import { useChannelStore } from "@/store/useChannelStore";
 
-const useChannelSwitchOnAd = () => {
+const useChannelSwitch = () => {
   const prevChannelId = useChannelStore((state) => state.prevChannelId);
   const setPrevChannelId = useChannelStore((state) => state.setPrevChannelId);
   const navigate = useNavigate();
@@ -31,4 +31,4 @@ const useChannelSwitchOnAd = () => {
   return handleChannelSwitch;
 };
 
-export default useChannelSwitchOnAd;
+export default useChannelSwitch;

--- a/src/hooks/useChannelSwitchOnAd.jsx
+++ b/src/hooks/useChannelSwitchOnAd.jsx
@@ -1,0 +1,34 @@
+import { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { useChannelStore } from "@/store/useChannelStore";
+
+const useChannelSwitchOnAd = () => {
+  const prevChannelId = useChannelStore((state) => state.prevChannelId);
+  const setPrevChannelId = useChannelStore((state) => state.setPrevChannelId);
+  const navigate = useNavigate();
+
+  const handleChannelSwitch = useCallback(
+    async (isAd) => {
+      try {
+        let channelId = 0;
+        if (isAd) {
+          // TODO: 광고 없는 채널 id 랜덤으로 불러오기
+          channelId = 3;
+          setPrevChannelId(channelId);
+        } else {
+          channelId = prevChannelId;
+          setPrevChannelId(null);
+        }
+        navigate(`/channel/${channelId}`);
+      } catch (error) {
+        console.error("switch failed: ", error);
+      }
+    },
+    [prevChannelId, setPrevChannelId, navigate]
+  );
+
+  return handleChannelSwitch;
+};
+
+export default useChannelSwitchOnAd;

--- a/src/store/useChannelStore.js
+++ b/src/store/useChannelStore.js
@@ -1,0 +1,7 @@
+import { create } from "zustand";
+
+export const useChannelStore = create((set) => ({
+  prevChannelId: null,
+
+  setPrevChannelId: (channelId) => set({ prevChannelId: channelId }),
+}));


### PR DESCRIPTION
### ✨ 이슈 번호

- #40 

### 📌 설명

- 광고가 탐지 여부에 따른 다른 라디오 채널로 전환하는 로직을 구현하여 작성한 Pull Request입니다.

### 📃 작업 사항

- [x] 채널 이동
  - [x] navigate 함수(/channel/:id)로 이동 
  - [x] 광고 없는 채널로 이동
- [x] 채널 이동 직전에 현재 channelId를 zustand에 저장

### 💭 리뷰 사항 반영

- [x] 채널 전환 훅 이름을 역할에 맞게 useChannelSwitch로 변경

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
