### PR TITLE
feat: 광고 시간대 기반 탐지 로직 구현

### DIFF
--- a/src/hooks/useAdTimeDetector.jsx
+++ b/src/hooks/useAdTimeDetector.jsx
@@ -1,6 +1,8 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 const useAdTimeDetector = (switchChannelOnAd) => {
+  const isAdTimeAlreadyHandled = useRef(false);
+
   useEffect(() => {
     const checkAdTime = () => {
       const now = new Date();
@@ -19,10 +21,18 @@ const useAdTimeDetector = (switchChannelOnAd) => {
         minutes === 59 ||
         (minutes === 0 && seconds === 0);
 
-      if (isPreThirtyAdTime || isPreHourAdTime) {
+      const isAdTime = isPreThirtyAdTime || isPreHourAdTime;
+
+      if (isAdTime && !isAdTimeAlreadyHandled.current) {
+        isAdTimeAlreadyHandled.current = true;
         switchChannelOnAd();
       }
+
+      if (!isAdTime && isAdTimeAlreadyHandled.current) {
+        isAdTimeAlreadyHandled.current = false;
+      }
     };
+
     const timer = setInterval(checkAdTime, 10000);
 
     return () => clearInterval(timer);

--- a/src/hooks/useAdTimeDetector.jsx
+++ b/src/hooks/useAdTimeDetector.jsx
@@ -1,19 +1,19 @@
 import { useEffect, useRef } from "react";
 
 const isAdTimeNow = (minutes, seconds) => {
-  const isPreThirtyAdTime =
+  const isPreHalfHourAdTime =
     (minutes === 27 && seconds >= 30) ||
     minutes === 28 ||
     minutes === 29 ||
     (minutes === 30 && seconds === 0);
 
-  const isPreHourAdTime =
+  const isPreOnHourAdTime =
     minutes === 57 ||
     minutes === 58 ||
     minutes === 59 ||
     (minutes === 0 && seconds === 0);
 
-  return isPreThirtyAdTime || isPreHourAdTime;
+  return isPreHalfHourAdTime || isPreOnHourAdTime;
 };
 
 const useAdTimeDetector = (handleChannelSwitch) => {

--- a/src/hooks/useAdTimeDetector.jsx
+++ b/src/hooks/useAdTimeDetector.jsx
@@ -29,11 +29,12 @@ const useAdTimeDetector = (switchChannelOnAd) => {
 
       if (isAdTime && !isAdTimeAlreadyHandled.current) {
         isAdTimeAlreadyHandled.current = true;
-        switchChannelOnAd();
+        switchChannelOnAd(true);
       }
 
       if (!isAdTime && isAdTimeAlreadyHandled.current) {
         isAdTimeAlreadyHandled.current = false;
+        switchChannelOnAd(false);
       }
     };
 

--- a/src/hooks/useAdTimeDetector.jsx
+++ b/src/hooks/useAdTimeDetector.jsx
@@ -1,0 +1,32 @@
+import { useEffect } from "react";
+
+const useAdTimeDetector = (switchChannelOnAd) => {
+  useEffect(() => {
+    const checkAdTime = () => {
+      const now = new Date();
+      const minutes = now.getMinutes();
+      const seconds = now.getSeconds();
+
+      const isPreThirtyAdTime =
+        (minutes === 27 && seconds >= 30) ||
+        minutes === 28 ||
+        minutes === 29 ||
+        (minutes === 30 && seconds === 0);
+
+      const isPreHourAdTime =
+        minutes === 57 ||
+        minutes === 58 ||
+        minutes === 59 ||
+        (minutes === 0 && seconds === 0);
+
+      if (isPreThirtyAdTime || isPreHourAdTime) {
+        switchChannelOnAd();
+      }
+    };
+    const timer = setInterval(checkAdTime, 10000);
+
+    return () => clearInterval(timer);
+  }, [switchChannelOnAd]);
+};
+
+export default useAdTimeDetector;

--- a/src/hooks/useAdTimeDetector.jsx
+++ b/src/hooks/useAdTimeDetector.jsx
@@ -22,10 +22,7 @@ const useAdTimeDetector = (handleChannelSwitch) => {
   useEffect(() => {
     const checkAdTime = () => {
       const now = new Date();
-      const minutes = now.getMinutes();
-      const seconds = now.getSeconds();
-
-      const isAdTime = isAdTimeNow(minutes, seconds);
+      const isAdTime = isAdTimeNow(now.getMinutes(), now.getSeconds());
 
       if (isAdTime && !isAdTimeAlreadyHandled.current) {
         isAdTimeAlreadyHandled.current = true;

--- a/src/hooks/useAdTimeDetector.jsx
+++ b/src/hooks/useAdTimeDetector.jsx
@@ -1,5 +1,21 @@
 import { useEffect, useRef } from "react";
 
+const isAdTimeNow = (minutes, seconds) => {
+  const isPreThirtyAdTime =
+    (minutes === 27 && seconds >= 30) ||
+    minutes === 28 ||
+    minutes === 29 ||
+    (minutes === 30 && seconds === 0);
+
+  const isPreHourAdTime =
+    minutes === 57 ||
+    minutes === 58 ||
+    minutes === 59 ||
+    (minutes === 0 && seconds === 0);
+
+  return isPreThirtyAdTime || isPreHourAdTime;
+};
+
 const useAdTimeDetector = (switchChannelOnAd) => {
   const isAdTimeAlreadyHandled = useRef(false);
 
@@ -9,19 +25,7 @@ const useAdTimeDetector = (switchChannelOnAd) => {
       const minutes = now.getMinutes();
       const seconds = now.getSeconds();
 
-      const isPreThirtyAdTime =
-        (minutes === 27 && seconds >= 30) ||
-        minutes === 28 ||
-        minutes === 29 ||
-        (minutes === 30 && seconds === 0);
-
-      const isPreHourAdTime =
-        minutes === 57 ||
-        minutes === 58 ||
-        minutes === 59 ||
-        (minutes === 0 && seconds === 0);
-
-      const isAdTime = isPreThirtyAdTime || isPreHourAdTime;
+      const isAdTime = isAdTimeNow(minutes, seconds);
 
       if (isAdTime && !isAdTimeAlreadyHandled.current) {
         isAdTimeAlreadyHandled.current = true;

--- a/src/hooks/useAdTimeDetector.jsx
+++ b/src/hooks/useAdTimeDetector.jsx
@@ -16,7 +16,7 @@ const isAdTimeNow = (minutes, seconds) => {
   return isPreThirtyAdTime || isPreHourAdTime;
 };
 
-const useAdTimeDetector = (switchChannelOnAd) => {
+const useAdTimeDetector = (handleChannelSwitch) => {
   const isAdTimeAlreadyHandled = useRef(false);
 
   useEffect(() => {
@@ -29,19 +29,19 @@ const useAdTimeDetector = (switchChannelOnAd) => {
 
       if (isAdTime && !isAdTimeAlreadyHandled.current) {
         isAdTimeAlreadyHandled.current = true;
-        switchChannelOnAd(true);
+        handleChannelSwitch(true);
       }
 
       if (!isAdTime && isAdTimeAlreadyHandled.current) {
         isAdTimeAlreadyHandled.current = false;
-        switchChannelOnAd(false);
+        handleChannelSwitch(false);
       }
     };
 
     const timer = setInterval(checkAdTime, 10000);
 
     return () => clearInterval(timer);
-  }, [switchChannelOnAd]);
+  }, [handleChannelSwitch]);
 };
 
 export default useAdTimeDetector;

--- a/src/hooks/useAdTimeDetector.jsx
+++ b/src/hooks/useAdTimeDetector.jsx
@@ -1,20 +1,6 @@
 import { useEffect, useRef } from "react";
 
-const isAdTimeNow = (minutes, seconds) => {
-  const isPreHalfHourAdTime =
-    (minutes === 27 && seconds >= 30) ||
-    minutes === 28 ||
-    minutes === 29 ||
-    (minutes === 30 && seconds === 0);
-
-  const isPreOnHourAdTime =
-    minutes === 57 ||
-    minutes === 58 ||
-    minutes === 59 ||
-    (minutes === 0 && seconds === 0);
-
-  return isPreHalfHourAdTime || isPreOnHourAdTime;
-};
+import isAdTimeNow from "@/utils/adTimeChecker";
 
 const useAdTimeDetector = (handleChannelSwitch) => {
   const isAdTimeAlreadyHandled = useRef(false);

--- a/src/utils/adTimeChecker.js
+++ b/src/utils/adTimeChecker.js
@@ -1,0 +1,17 @@
+const isAdTimeNow = (minutes, seconds) => {
+  const isPreHalfHourAdTime =
+    (minutes === 27 && seconds >= 30) ||
+    minutes === 28 ||
+    minutes === 29 ||
+    (minutes === 30 && seconds === 0);
+
+  const isPreOnHourAdTime =
+    minutes === 57 ||
+    minutes === 58 ||
+    minutes === 59 ||
+    (minutes === 0 && seconds === 0);
+
+  return isPreHalfHourAdTime || isPreOnHourAdTime;
+};
+
+export default isAdTimeNow;


### PR DESCRIPTION
### ✨ 이슈 번호 

- #41 

### 📌 설명 

- MBC, KBS, SBS 라디오 방송사별로 조사된 광고 시간대를 기반으로 현재 청취 중인 채널이 해당 시간대와 일치할 경우, 광고로 판단하여 자동으로 다른 채널로 이동시키는 함수를 호출하는 로직을 구현한 Pull Request 입니다.
- 광고 시간대는 방송사 광고 조사를 바탕으로 사전에 정의된 패턴을 기준으로 판단합니다.
- 해당 시간대에 진입하거나 빠져나올 때 단 1회만 함수가 호출되도록 구현했습니다.

### 📃 작업 사항 

- [X] 광고 시간대 정의 및 감지 로직 구현
- [X] 광고 시간대 진입 시 `handleChannelSwitch(true)` 호출
- [X] 광고 시간대에서 빠져나올 시 `handleChannelSwitch(false)` 호출
- [X] 함수 중복 호출 방지를 위해 `useRef`사용
  
### 💡 참고 사항
**`ref`를 사용한 이유**
처음에는 광고 시간대에 들어갈 때 `handleChannelSwitch()`를 호출하도록 구현했지만,
이 방식은 `setInterval`로 10초마다 광고 시간대 여부를 체크하면서 같은 광고 시간대 안에서는 함수가 반복 호출되는 문제가 발생했습니다.

![image](https://github.com/user-attachments/assets/e1881574-3de7-4e1c-bf94-43c7feea70f6)

이를 해결하기 위해:
이전 광고 감지 상태를 기억할 수 있는 상태가 필요했고 렌더링과는 무관하게 유지되어야 했기 때문에 `useRef`를 사용하여 이전 상태를 기억하고 중복 호출을 방지하도록 리팩토링했습니다.

### 💭 리뷰 사항 반영 

- [X] now.getMinutes(), getSeconds() 직접 전달로 단순화
- [X] 광고 시간대 변수명 의미 통일
- [X] 광고 시간 판별 로직 유틸 함수로 분리

### ✅ Pull Request 체크 사항

- [X] 가장 최신 브랜치를 pull 하였습니다.
- [X] base 브랜치명을 확인하였습니다.
- [X] 코드 컨벤션을 모두 확인하였습니다.
- [X] 브랜치명을 확인하였습니다.
