### PR TITLE
feat: 신규 사용자 등록 API 연동

### DIFF
--- a/src/hooks/useUserId.jsx
+++ b/src/hooks/useUserId.jsx
@@ -1,0 +1,27 @@
+import axios from "axios";
+import { useEffect, useState } from "react";
+
+const useUserId = () => {
+  const [userId, setUserId] = useState(null);
+
+  useEffect(() => {
+    const fetchUserId = async () => {
+      const storedId = localStorage.getItem("userId");
+
+      if (storedId === null) {
+        const {
+          data: { userId },
+        } = await axios.post(`${import.meta.env.VITE_API_URL}/users`);
+        localStorage.setItem("userId", userId);
+      } else {
+        setUserId(storedId);
+      }
+    };
+
+    fetchUserId();
+  }, []);
+
+  return userId;
+};
+
+export default useUserId;

--- a/src/hooks/useUserId.jsx
+++ b/src/hooks/useUserId.jsx
@@ -9,10 +9,14 @@ const useUserId = () => {
       const storedId = localStorage.getItem("userId");
 
       if (storedId === null) {
-        const {
-          data: { userId },
-        } = await axios.post(`${import.meta.env.VITE_API_URL}/users`);
-        localStorage.setItem("userId", userId);
+        try {
+          const {
+            data: { userId },
+          } = await axios.post(`${import.meta.env.VITE_API_URL}/users`);
+          localStorage.setItem("userId", userId);
+        } catch (error) {
+          console.error("fetch userId failed: ", error);
+        }
       } else {
         setUserId(storedId);
       }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -6,9 +6,8 @@ import useCategorizeChannels from "@/hooks/useCategorizeChannel";
 import useUserId from "@/hooks/useUserId";
 
 const Home = () => {
-  useUserId();
-
-  const [channelList, favoriteChannelList] = useCategorizeChannels();
+  const userId = useUserId();
+  const [channelList, favoriteChannelList] = useCategorizeChannels(userId);
 
   return (
     <>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -3,8 +3,11 @@ import ChannelSection from "@/components/ChannelSection";
 import FavoriteChannelList from "@/components/FavoriteChannelList";
 import TabBar from "@/components/TabBar";
 import useCategorizeChannels from "@/hooks/useCategorizeChannel";
+import useUserId from "@/hooks/useUserId";
 
 const Home = () => {
+  useUserId();
+
   const [channelList, favoriteChannelList] = useCategorizeChannels();
 
   return (


### PR DESCRIPTION
### ✨ 이슈 번호

- #45 

### 📌 설명

로컬스토리지에 'userId'가 존재하는지 여부에 따라 신규 사용자 등록을 진행하고 신규 사용자 등록 API를 연동합니다.

### 📃 작업 사항

- [x]  백엔드에서 구현한 신규 사용자 등록 구현 API를 연동한다.
- [x]  메인 화면에 진입했을 때, localStorage에 userId 값이 존재하지 않는 경우 신규 사용자 등록 API를 호출한다.
- [x]  메인 화면에 진입했을 때, localStorage에 userId 값이 존재하는 경우 신규 사용자 등록 API를 호출하지 않는다.

### 💡 참고 사항 

사용자 정보인 `userId`는 `localStorage`에 저장합니다. `localStorage`는 브라우저를 닫거나 종료해도 데이터가 유지되며 동일한 도메인 내의 모든 탭과 창에서 데이터를 공유합니다. 또한, 데이터를 사용자가 직접 삭제하거나 브라우저 캐시를 지우기 전까지 데이터가 유지됩니다.

`localStorage.setItem`을 통해 원하는 정보를 `localStorage`에 저장할 수 있고, `localStorage.getItem`을 통해 원하는 정보를 `localStorage`에서 가져올 수 있습니다. 존재하지 않는 아이템을 가져올 때 `null`을 반환하는데 이를 이용하여 신규 사용자인지 기존 사용자인지 구분합니다.

<img width="293" alt="image" src="https://github.com/user-attachments/assets/16fcb124-6f38-4892-a055-250b2b7e0eca" />


### 💭 리뷰 사항 반영

- [x] `try-catch`로 감싸기

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
