### PR TITLE
feat: 재생 버튼 클릭 시 라디오 재생 로직 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
         "@tailwindcss/vite": "^4.1.7",
+        "hls.js": "^1.6.5",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.1",
@@ -4489,6 +4490,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hls.js": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.5.tgz",
+      "integrity": "sha512-KMn5n7JBK+olC342740hDPHnGWfE8FiHtGMOdJPfUjRdARTWj9OB+8c13fnsf9sk1VtpuU2fKSgUjHvg4rNbzQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/husky": {
       "version": "9.1.7",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@tailwindcss/vite": "^4.1.7",
+    "hls.js": "^1.6.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.1",

--- a/src/components/MiniPlayer.jsx
+++ b/src/components/MiniPlayer.jsx
@@ -3,14 +3,14 @@ import { useState, useRef } from "react";
 import CloseIcon from "@/assets/svgs/icon-close.svg?react";
 import PauseIcon from "@/assets/svgs/icon-mini-pause.svg?react";
 import PlayIcon from "@/assets/svgs/icon-mini-player.svg?react";
-import controlStreamPlayback from "@/utils/playControl";
+import controlStreamingPlayback from "@/utils/playControl";
 
 const MiniPlayer = ({ thumbnail, channelName, closePlayer }) => {
   const [isPlaying, setIsPlaying] = useState(false);
   const videoId = useRef(null);
 
   const handlePlayPause = () => {
-    controlStreamPlayback(videoId, !isPlaying);
+    controlStreamingPlayback(videoId, !isPlaying);
     setIsPlaying((prev) => !prev);
   };
 

--- a/src/components/MiniPlayer.jsx
+++ b/src/components/MiniPlayer.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 
 import CloseIcon from "@/assets/svgs/icon-close.svg?react";
 import PauseIcon from "@/assets/svgs/icon-mini-pause.svg?react";
@@ -7,9 +7,10 @@ import controlStreamPlayback from "@/utils/playControl";
 
 const MiniPlayer = ({ thumbnail, channelName, closePlayer }) => {
   const [isPlaying, setIsPlaying] = useState(false);
+  const videoId = useRef(null);
 
   const handlePlayPause = () => {
-    controlStreamPlayback("radio-player", !isPlaying);
+    controlStreamPlayback(videoId, !isPlaying);
     setIsPlaying((prev) => !prev);
   };
 
@@ -23,7 +24,7 @@ const MiniPlayer = ({ thumbnail, channelName, closePlayer }) => {
         />
         <p className="ml-2 text-sm font-black">{channelName}</p>
       </div>
-      <video id="radio-player" className="hidden" />
+      <video ref={videoId} className="hidden" />
       <div className="flex items-center gap-3">
         {!isPlaying ? (
           <PlayIcon

--- a/src/components/MiniPlayer.jsx
+++ b/src/components/MiniPlayer.jsx
@@ -3,11 +3,13 @@ import { useState } from "react";
 import CloseIcon from "@/assets/svgs/icon-close.svg?react";
 import PauseIcon from "@/assets/svgs/icon-mini-pause.svg?react";
 import PlayIcon from "@/assets/svgs/icon-mini-player.svg?react";
+import controlStreamPlayback from "@/utils/playControl";
 
 const MiniPlayer = ({ thumbnail, channelName, closePlayer }) => {
   const [isPlaying, setIsPlaying] = useState(false);
 
   const handlePlayPause = () => {
+    controlStreamPlayback("radio-player", !isPlaying);
     setIsPlaying((prev) => !prev);
   };
 
@@ -21,6 +23,7 @@ const MiniPlayer = ({ thumbnail, channelName, closePlayer }) => {
         />
         <p className="ml-2 text-sm font-black">{channelName}</p>
       </div>
+      <video id="radio-player" className="hidden" />
       <div className="flex items-center gap-3">
         {!isPlaying ? (
           <PlayIcon

--- a/src/hooks/useUserId.jsx
+++ b/src/hooks/useUserId.jsx
@@ -1,0 +1,31 @@
+import axios from "axios";
+import { useEffect, useState } from "react";
+
+const useUserId = () => {
+  const [userId, setUserId] = useState(null);
+
+  useEffect(() => {
+    const fetchUserId = async () => {
+      const storedId = localStorage.getItem("userId");
+
+      if (storedId === null) {
+        try {
+          const {
+            data: { userId },
+          } = await axios.post(`${import.meta.env.VITE_API_URL}/users`);
+          localStorage.setItem("userId", userId);
+        } catch (error) {
+          console.error("fetch userId failed: ", error);
+        }
+      } else {
+        setUserId(storedId);
+      }
+    };
+
+    fetchUserId();
+  }, []);
+
+  return userId;
+};
+
+export default useUserId;

--- a/src/pages/ChannelPlayer.jsx
+++ b/src/pages/ChannelPlayer.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 
 import MainPauseIcon from "@/assets/svgs/icon-main-pause.svg?react";
 import MainPlayIcon from "@/assets/svgs/icon-main-play.svg?react";
@@ -9,6 +9,8 @@ import controlStreamPlayback from "@/utils/playControl";
 
 const ChannelPlayer = ({ isChannelChanged }) => {
   const [isPlaying, setIsPlaying] = useState(false);
+  const videoId = useRef(null);
+
   // 데이터 연결 전 임시 값 할당
   const logoUrl =
     "https://www.urbanbrush.net/web/wp-content/uploads/edd/2019/08/urbanbrush-20190805082332272597.png";
@@ -18,7 +20,7 @@ const ChannelPlayer = ({ isChannelChanged }) => {
     : SETTING_TITLES[SETTING_TYPES.AD_DETECT];
 
   const handlePlayPause = () => {
-    controlStreamPlayback("radio-player", !isPlaying);
+    controlStreamPlayback(videoId, !isPlaying);
     setIsPlaying((prev) => !prev);
   };
 
@@ -37,7 +39,7 @@ const ChannelPlayer = ({ isChannelChanged }) => {
           <p className="text-sm font-semibold sm:text-base">{buttonLabel}</p>
           <ToggleButton size="s" />
         </div>
-        <video id="radio-player" className="hidden" />
+        <video ref={videoId} className="hidden" />
         <Button className="mt-12" onClick={handlePlayPause}>
           {isPlaying ? (
             <MainPauseIcon className="h-[60px] w-[60px] sm:h-[75px] sm:w-[75px]" />

--- a/src/pages/ChannelPlayer.jsx
+++ b/src/pages/ChannelPlayer.jsx
@@ -5,19 +5,20 @@ import MainPlayIcon from "@/assets/svgs/icon-main-play.svg?react";
 import Button from "@/components/ui/Button";
 import ToggleButton from "@/components/ui/ToggleButton";
 import { SETTING_TYPES, SETTING_TITLES } from "@/constants/settingOptions";
+import controlStreamPlayback from "@/utils/playControl";
 
 const ChannelPlayer = ({ isChannelChanged }) => {
+  const [isPlaying, setIsPlaying] = useState(false);
   // 데이터 연결 전 임시 값 할당
   const logoUrl =
     "https://www.urbanbrush.net/web/wp-content/uploads/edd/2019/08/urbanbrush-20190805082332272597.png";
   const channelTitle = "RDO 라디오방송";
-  const [isPlaying, setIsPlaying] = useState(false);
-
   const buttonLabel = isChannelChanged
     ? SETTING_TITLES[SETTING_TYPES.RETURN_CHANNEL]
     : SETTING_TITLES[SETTING_TYPES.AD_DETECT];
 
   const handlePlayPause = () => {
+    controlStreamPlayback("radio-player", !isPlaying);
     setIsPlaying((prev) => !prev);
   };
 
@@ -36,6 +37,7 @@ const ChannelPlayer = ({ isChannelChanged }) => {
           <p className="text-sm font-semibold sm:text-base">{buttonLabel}</p>
           <ToggleButton size="s" />
         </div>
+        <video id="radio-player" className="hidden" />
         <Button className="mt-12" onClick={handlePlayPause}>
           {isPlaying ? (
             <MainPauseIcon className="h-[60px] w-[60px] sm:h-[75px] sm:w-[75px]" />

--- a/src/pages/ChannelPlayer.jsx
+++ b/src/pages/ChannelPlayer.jsx
@@ -5,7 +5,7 @@ import MainPlayIcon from "@/assets/svgs/icon-main-play.svg?react";
 import Button from "@/components/ui/Button";
 import ToggleButton from "@/components/ui/ToggleButton";
 import { SETTING_TYPES, SETTING_TITLES } from "@/constants/settingOptions";
-import controlStreamPlayback from "@/utils/playControl";
+import controlStreamingPlayback from "@/utils/playControl";
 
 const ChannelPlayer = ({ isChannelChanged }) => {
   const [isPlaying, setIsPlaying] = useState(false);
@@ -20,7 +20,7 @@ const ChannelPlayer = ({ isChannelChanged }) => {
     : SETTING_TITLES[SETTING_TYPES.AD_DETECT];
 
   const handlePlayPause = () => {
-    controlStreamPlayback(videoId, !isPlaying);
+    controlStreamingPlayback(videoId, !isPlaying);
     setIsPlaying((prev) => !prev);
   };
 

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -3,9 +3,11 @@ import ChannelSection from "@/components/ChannelSection";
 import FavoriteChannelList from "@/components/FavoriteChannelList";
 import TabBar from "@/components/TabBar";
 import useCategorizeChannels from "@/hooks/useCategorizeChannel";
+import useUserId from "@/hooks/useUserId";
 
 const Home = () => {
-  const [channelList, favoriteChannelList] = useCategorizeChannels();
+  const userId = useUserId();
+  const [channelList, favoriteChannelList] = useCategorizeChannels(userId);
 
   return (
     <>

--- a/src/utils/playControl.js
+++ b/src/utils/playControl.js
@@ -1,0 +1,27 @@
+import Hls from "hls.js";
+
+const STREAM_URL =
+  "https://mgugaklive.nowcdn.co.kr/gugakradio/gugakradio.stream/playlist.m3u8";
+let hlsInstance = null;
+
+const controlStreamPlayback = (videoId, isPlaying) => {
+  const video = document.getElementById(videoId);
+
+  if (isPlaying) {
+    if (Hls.isSupported()) {
+      hlsInstance = new Hls();
+      hlsInstance.loadSource(STREAM_URL);
+      hlsInstance.attachMedia(video);
+      hlsInstance.on(Hls.Events.MANIFEST_PARSED, () => {
+        video.play();
+      });
+    } else if (video.canPlayType("application/vnd.apple.mpegurl")) {
+      video.src = STREAM_URL;
+      video.play();
+    }
+  } else {
+    video.pause();
+  }
+};
+
+export default controlStreamPlayback;

--- a/src/utils/playControl.js
+++ b/src/utils/playControl.js
@@ -5,7 +5,7 @@ const STREAM_URL =
 let hlsInstance = null;
 
 const controlStreamPlayback = (videoId, isPlaying) => {
-  const video = document.getElementById(videoId);
+  const video = videoId.current;
 
   if (isPlaying) {
     if (Hls.isSupported()) {

--- a/src/utils/playControl.js
+++ b/src/utils/playControl.js
@@ -4,7 +4,7 @@ const STREAM_URL =
   "https://mgugaklive.nowcdn.co.kr/gugakradio/gugakradio.stream/playlist.m3u8";
 let hlsInstance = null;
 
-const controlStreamPlayback = (videoId, isPlaying) => {
+const controlStreamingPlayback = (videoId, isPlaying) => {
   const video = videoId.current;
 
   if (isPlaying) {
@@ -24,4 +24,4 @@ const controlStreamPlayback = (videoId, isPlaying) => {
   }
 };
 
-export default controlStreamPlayback;
+export default controlStreamingPlayback;


### PR DESCRIPTION
### ✨ 이슈 번호 

- #44 

### 📌 설명 

- 오디오 스트리밍 재생 함수를 구현하고, MiniPlayer와 ChannelPlayer에 적용한 Pull Request입니다.

### 📃 작업 사항 

- [X] hls.js 라이브러리 설치
- [X] 스트리밍 재생/일시정지 유틸 함수(controlStreamPlayback) 구현
- [X] MiniPlayer에 스트리밍 재생 기능 연동
- [X] ChannelPlayer에 동일 기능 적용

### 💡 참고 사항 
**🔊 스트리밍 재생 시점에 콘솔에 로그가 출력**

![스트리밍 재생 로그 캡처](https://github.com/user-attachments/assets/6171270a-6b2f-40bf-b9ba-4a7ef180812d)

### 💭 리뷰 사항 반영 

### ✅ Pull Request 체크 사항

- [X] 가장 최신 브랜치를 pull 하였습니다.
- [X] base 브랜치명을 확인하였습니다.
- [X] 코드 컨벤션을 모두 확인하였습니다.
- [X] 브랜치명을 확인하였습니다.
