### PR TITLE
feat: 라디오 채널 목록 조회 API 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.env

--- a/src/hooks/useChannels.jsx
+++ b/src/hooks/useChannels.jsx
@@ -12,10 +12,14 @@ const useChannels = () => {
     }
 
     const initChannels = async () => {
-      const { data } = await axios.get(
-        `${import.meta.env.VITE_API_URL}/radio-channels`
-      );
-      setRadioChannelList(data);
+      try {
+        const { data } = await axios.get(
+          `${import.meta.env.VITE_API_URL}/radio-channels`
+        );
+        setRadioChannelList(data);
+      } catch (error) {
+        console.error("fetch radioChannels failed: ", error);
+      }
     };
     initChannels();
   }, [radioChannelList, setRadioChannelList]);

--- a/src/hooks/useChannels.jsx
+++ b/src/hooks/useChannels.jsx
@@ -7,7 +7,9 @@ const useChannels = () => {
   const { radioChannelList, setRadioChannelList } = useChannelStore();
 
   useEffect(() => {
-    if (radioChannelList.length > 0) return;
+    if (radioChannelList.length > 0) {
+      return;
+    }
 
     const initChannels = async () => {
       const { data } = await axios.get(

--- a/src/hooks/useChannels.jsx
+++ b/src/hooks/useChannels.jsx
@@ -1,0 +1,22 @@
+import axios from "axios";
+import { useEffect } from "react";
+
+import { useChannelStore } from "@/store/useChannelStore";
+
+const useChannels = () => {
+  const { radioChannelList, setRadioChannelList } = useChannelStore();
+
+  useEffect(() => {
+    if (radioChannelList.length > 0) return;
+
+    const initChannels = async () => {
+      const { data } = await axios.get(
+        `${import.meta.env.VITE_API_URL}/radio-channels`
+      );
+      setRadioChannelList(data);
+    };
+    initChannels();
+  }, [radioChannelList, setRadioChannelList]);
+};
+
+export default useChannels;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -3,8 +3,10 @@ import ChannelSection from "@/components/ChannelSection";
 import FavoriteChannelList from "@/components/FavoriteChannelList";
 import TabBar from "@/components/TabBar";
 import useCategorizeChannels from "@/hooks/useCategorizeChannel";
+import useChannels from "@/hooks/useChannels";
 
 const Home = () => {
+  useChannels();
   const [channelList, favoriteChannelList] = useCategorizeChannels();
 
   return (

--- a/src/store/useChannelStore.js
+++ b/src/store/useChannelStore.js
@@ -1,7 +1,9 @@
 import { create } from "zustand";
 
 export const useChannelStore = create((set) => ({
+  radioChannelList: [],
   prevChannelId: null,
 
-  setPrevChannelId: (channelId) => set({ prevChannelId: channelId }),
+  setRadioChannelList: (list) => set({ radioChannelList: list }),
+  setPrevChannelId: (id) => set({ prevChannelId: id }),
 }));

--- a/src/store/useChannelStore.js
+++ b/src/store/useChannelStore.js
@@ -4,6 +4,6 @@ export const useChannelStore = create((set) => ({
   radioChannelList: [],
   prevChannelId: null,
 
-  setRadioChannelList: (list) => set({ radioChannelList: list }),
-  setPrevChannelId: (id) => set({ prevChannelId: id }),
+  setRadioChannelList: (channelList) => set({ radioChannelList: channelList }),
+  setPrevChannelId: (channelId) => set({ prevChannelId: channelId }),
 }));


### PR DESCRIPTION
### ✨ 이슈 번호

- #46 

### 📌 설명

- 라디오 채널 목록 조회 API를 연동을 구현하여 작성한 Pull Request입니다.

### 📃 작업 사항

- [x] 라디오 전체 채널 목록 상태 관리 store 및 `useChannels` 훅 구현
  - [x] 전체 라디오 채널 목록을 zustand에 초기 로딩하는 `useChannels` 훅 구현
  - [x] 라디오 전체 채널 목록 zustand 기반 채널 상태 관리 store 정의
  - [x] 홈화면에 useChannels 훅 추가

### 💭 리뷰 사항 반영

- [x] 명시적 이름 사용 `channelList`
- [x] 에러 상황을 고려하여 `try...catch` 추가
- [x] 중괄호 추가
 
### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
