### PR TITLE
feat: 라디오 채널 정보 조회 API 연동

### DIFF
--- a/src/components/ChannelListItem.jsx
+++ b/src/components/ChannelListItem.jsx
@@ -1,14 +1,19 @@
 import BlankStarIcon from "@/assets/svgs/icon-blank-star.svg?react";
+import useChannelNavigation from "@/hooks/useChannelNavigation";
 
 const ChannelListItem = ({
   thumbnail,
+  channelId,
   channelName,
   onToggleFavorite,
   backgroundColor,
 }) => {
+  const navigateToChannelPlayer = useChannelNavigation();
+
   return (
     <li
       className={`my-2 flex h-16 w-full items-center rounded-md ${backgroundColor} pr-5 pl-6`}
+      onClick={() => navigateToChannelPlayer(channelId)}
     >
       <img
         className="h-12 w-12"

--- a/src/components/ChannelListItem.jsx
+++ b/src/components/ChannelListItem.jsx
@@ -8,12 +8,12 @@ const ChannelListItem = ({
   onToggleFavorite,
   backgroundColor,
 }) => {
-  const navigateToChannelPlayer = useChannelNavigation();
+  const goToChannelPlayer = useChannelNavigation();
 
   return (
     <li
       className={`my-2 flex h-16 w-full items-center rounded-md ${backgroundColor} pr-5 pl-6`}
-      onClick={() => navigateToChannelPlayer(channelId)}
+      onClick={() => goToChannelPlayer(channelId)}
     >
       <img
         className="h-12 w-12"

--- a/src/components/FavoriteChannelListItem.jsx
+++ b/src/components/FavoriteChannelListItem.jsx
@@ -3,6 +3,7 @@ import { CSS } from "@dnd-kit/utilities";
 
 import DragDropIcon from "@/assets/svgs/icon-drag-drop.svg?react";
 import FilledStarIcon from "@/assets/svgs/icon-filled-star.svg?react";
+import useChannelNavigation from "@/hooks/useChannelNavigation";
 
 const FavoriteChannelListItem = ({ id, name }) => {
   const {
@@ -14,6 +15,7 @@ const FavoriteChannelListItem = ({ id, name }) => {
     transform,
     transition,
   } = useSortable({ id });
+  const navigateToChannelPlayer = useChannelNavigation();
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -26,6 +28,7 @@ const FavoriteChannelListItem = ({ id, name }) => {
       style={style}
       {...attributes}
       className="my-2 flex h-16 w-full items-center rounded-md bg-gray-100 p-2 select-none"
+      onClick={() => navigateToChannelPlayer(id)}
     >
       <div className="h-12 w-12 flex-none rounded-lg bg-gray-200" />
       <p className="ml-3 w-3/5 flex-1 truncate overflow-hidden text-sm font-bold whitespace-nowrap">

--- a/src/components/FavoriteChannelListItem.jsx
+++ b/src/components/FavoriteChannelListItem.jsx
@@ -15,7 +15,7 @@ const FavoriteChannelListItem = ({ id, name }) => {
     transform,
     transition,
   } = useSortable({ id });
-  const navigateToChannelPlayer = useChannelNavigation();
+  const goToChannelPlayer = useChannelNavigation();
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -28,7 +28,7 @@ const FavoriteChannelListItem = ({ id, name }) => {
       style={style}
       {...attributes}
       className="my-2 flex h-16 w-full items-center rounded-md bg-gray-100 p-2 select-none"
-      onClick={() => navigateToChannelPlayer(id)}
+      onClick={() => goToChannelPlayer(id)}
     >
       <div className="h-12 w-12 flex-none rounded-lg bg-gray-200" />
       <p className="ml-3 w-3/5 flex-1 truncate overflow-hidden text-sm font-bold whitespace-nowrap">

--- a/src/hooks/useChannelInfo.jsx
+++ b/src/hooks/useChannelInfo.jsx
@@ -2,7 +2,7 @@ import axios from "axios";
 import { useEffect, useState } from "react";
 
 const useChannelInfo = (channelId) => {
-  const [channelInfo, setChannelInfo] = useState({});
+  const [channelInfo, setChannelInfo] = useState(null);
 
   useEffect(() => {
     const fetchChannelInfo = async () => {

--- a/src/hooks/useChannelInfo.jsx
+++ b/src/hooks/useChannelInfo.jsx
@@ -1,11 +1,11 @@
 import axios from "axios";
 import { useEffect, useState } from "react";
 
-const useFetchChannel = (channelId) => {
+const useChannelInfo = (channelId) => {
   const [channelInfo, setChannelInfo] = useState({});
 
   useEffect(() => {
-    const fetchChannel = async () => {
+    const fetchChannelInfo = async () => {
       try {
         const { data } = await axios.get(
           `${import.meta.env.VITE_API_URL}/radio-channels/${channelId}`
@@ -16,10 +16,10 @@ const useFetchChannel = (channelId) => {
       }
     };
 
-    fetchChannel();
+    fetchChannelInfo();
   }, [channelId]);
 
   return channelInfo;
 };
 
-export default useFetchChannel;
+export default useChannelInfo;

--- a/src/hooks/useChannelNavigation.jsx
+++ b/src/hooks/useChannelNavigation.jsx
@@ -8,12 +8,12 @@ const useChannelNavigation = () => {
     (state) => state.setSelectedChannelId
   );
 
-  const navigateToChannelPlayer = (channelId) => {
+  const goToChannelPlayer = (channelId) => {
     setSelectedChannelId(channelId);
     navigate("/channel-player");
   };
 
-  return navigateToChannelPlayer;
+  return goToChannelPlayer;
 };
 
 export default useChannelNavigation;

--- a/src/hooks/useChannelNavigation.jsx
+++ b/src/hooks/useChannelNavigation.jsx
@@ -1,0 +1,19 @@
+import { useNavigate } from "react-router-dom";
+
+import { useChannelStore } from "@/store/useChannelStore";
+
+const useChannelNavigation = () => {
+  const navigate = useNavigate();
+  const setSelectedChannelId = useChannelStore(
+    (state) => state.setSelectedChannelId
+  );
+
+  const navigateToChannelPlayer = (channelId) => {
+    setSelectedChannelId(channelId);
+    navigate("/channel-player");
+  };
+
+  return navigateToChannelPlayer;
+};
+
+export default useChannelNavigation;

--- a/src/hooks/useChannelSwitch.jsx
+++ b/src/hooks/useChannelSwitch.jsx
@@ -1,12 +1,10 @@
 import { useCallback } from "react";
-import { useNavigate } from "react-router-dom";
 
 import { useChannelStore } from "@/store/useChannelStore";
 
 const useChannelSwitch = () => {
   const prevChannelId = useChannelStore((state) => state.prevChannelId);
   const setPrevChannelId = useChannelStore((state) => state.setPrevChannelId);
-  const navigate = useNavigate();
 
   const handleChannelSwitch = useCallback(
     async (isAd) => {
@@ -20,12 +18,13 @@ const useChannelSwitch = () => {
           channelId = prevChannelId;
           setPrevChannelId(null);
         }
-        navigate(`/channel/${channelId}`);
+        // TODO: 멈춤없이 라디오 음성을 연속 재생하려면 네비게이팅이 아닌 video의 src 속성을 변경해야 함
+        // navigate(`/channel/${channelId}`);
       } catch (error) {
         console.error("switch failed: ", error);
       }
     },
-    [prevChannelId, setPrevChannelId, navigate]
+    [prevChannelId, setPrevChannelId]
   );
 
   return handleChannelSwitch;

--- a/src/hooks/useFetchChannel.jsx
+++ b/src/hooks/useFetchChannel.jsx
@@ -1,0 +1,25 @@
+import axios from "axios";
+import { useEffect, useState } from "react";
+
+const useFetchChannel = (channelId) => {
+  const [channelInfo, setChannelInfo] = useState({});
+
+  useEffect(() => {
+    const fetchChannel = async () => {
+      try {
+        const { data } = await axios.get(
+          `${import.meta.env.VITE_API_URL}/radio-channels/${channelId}`
+        );
+        setChannelInfo(data);
+      } catch (error) {
+        console.error("fetch channelInfo failed", error);
+      }
+    };
+
+    fetchChannel();
+  }, [channelId]);
+
+  return channelInfo;
+};
+
+export default useFetchChannel;

--- a/src/pages/ChannelPlayer.jsx
+++ b/src/pages/ChannelPlayer.jsx
@@ -5,13 +5,13 @@ import MainPlayIcon from "@/assets/svgs/icon-main-play.svg?react";
 import Button from "@/components/ui/Button";
 import ToggleButton from "@/components/ui/ToggleButton";
 import { SETTING_TYPES, SETTING_TITLES } from "@/constants/settingOptions";
-import useFetchChannel from "@/hooks/useFetchChannel";
+import useChannelInfo from "@/hooks/useChannelInfo";
 import { useChannelStore } from "@/store/useChannelStore";
 import controlStreamingPlayback from "@/utils/playControl";
 
 const ChannelPlayer = ({ isChannelChanged }) => {
   const selectedChannelId = useChannelStore((state) => state.selectedChannelId);
-  const { name, url, logoUrl } = useFetchChannel(selectedChannelId);
+  const { name, url, logoUrl } = useChannelInfo(selectedChannelId);
   const [isPlaying, setIsPlaying] = useState(false);
   const videoId = useRef(null);
 

--- a/src/pages/ChannelPlayer.jsx
+++ b/src/pages/ChannelPlayer.jsx
@@ -5,22 +5,22 @@ import MainPlayIcon from "@/assets/svgs/icon-main-play.svg?react";
 import Button from "@/components/ui/Button";
 import ToggleButton from "@/components/ui/ToggleButton";
 import { SETTING_TYPES, SETTING_TITLES } from "@/constants/settingOptions";
+import useFetchChannel from "@/hooks/useFetchChannel";
+import { useChannelStore } from "@/store/useChannelStore";
 import controlStreamingPlayback from "@/utils/playControl";
 
 const ChannelPlayer = ({ isChannelChanged }) => {
+  const selectedChannelId = useChannelStore((state) => state.selectedChannelId);
+  const { name, url, logoUrl } = useFetchChannel(selectedChannelId);
   const [isPlaying, setIsPlaying] = useState(false);
   const videoId = useRef(null);
 
-  // 데이터 연결 전 임시 값 할당
-  const logoUrl =
-    "https://www.urbanbrush.net/web/wp-content/uploads/edd/2019/08/urbanbrush-20190805082332272597.png";
-  const channelTitle = "RDO 라디오방송";
   const buttonLabel = isChannelChanged
     ? SETTING_TITLES[SETTING_TYPES.RETURN_CHANNEL]
     : SETTING_TITLES[SETTING_TYPES.AD_DETECT];
 
   const handlePlayPause = () => {
-    controlStreamingPlayback(videoId, !isPlaying);
+    controlStreamingPlayback(videoId, url, !isPlaying);
     setIsPlaying((prev) => !prev);
   };
 
@@ -33,7 +33,7 @@ const ChannelPlayer = ({ isChannelChanged }) => {
           alt="채널 로고"
         />
         <p className="mt-3.5 text-center text-lg font-bold sm:text-xl">
-          {channelTitle}
+          {name}
         </p>
         <div className="mt-2 flex items-center gap-x-2">
           <p className="text-sm font-semibold sm:text-base">{buttonLabel}</p>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -20,6 +20,7 @@ const Home = () => {
           {channelList.map(({ channelId, name, logoUrl }) => (
             <ChannelListItem
               key={channelId}
+              channelId={channelId}
               channelName={name}
               thumbnail={logoUrl}
             />

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -14,7 +14,7 @@ const router = createBrowserRouter([
     children: [
       { path: "", element: <Home /> },
       { path: "search-result", element: <Search /> },
-      { path: "channel/:id", element: <ChannelPlayer /> },
+      { path: "channel-player", element: <ChannelPlayer /> },
       { path: "settings", element: <Settings /> },
     ],
   },

--- a/src/store/useChannelStore.js
+++ b/src/store/useChannelStore.js
@@ -2,6 +2,8 @@ import { create } from "zustand";
 
 export const useChannelStore = create((set) => ({
   prevChannelId: null,
+  selectedChannelId: null,
 
   setPrevChannelId: (channelId) => set({ prevChannelId: channelId }),
+  setSelectedChannelId: (channelId) => set({ selectedChannelId: channelId }),
 }));

--- a/src/utils/playControl.js
+++ b/src/utils/playControl.js
@@ -1,22 +1,20 @@
 import Hls from "hls.js";
 
-const STREAM_URL =
-  "https://mgugaklive.nowcdn.co.kr/gugakradio/gugakradio.stream/playlist.m3u8";
 let hlsInstance = null;
 
-const controlStreamingPlayback = (videoId, isPlaying) => {
+const controlStreamingPlayback = (videoId, videoUrl, isPlaying) => {
   const video = videoId.current;
 
   if (isPlaying) {
     if (Hls.isSupported()) {
       hlsInstance = new Hls();
-      hlsInstance.loadSource(STREAM_URL);
+      hlsInstance.loadSource(videoUrl);
       hlsInstance.attachMedia(video);
       hlsInstance.on(Hls.Events.MANIFEST_PARSED, () => {
         video.play();
       });
     } else if (video.canPlayType("application/vnd.apple.mpegurl")) {
-      video.src = STREAM_URL;
+      video.src = videoUrl;
       video.play();
     }
   } else {


### PR DESCRIPTION
### ✨ 이슈 번호 51

- #51 

### 📌 설명

라디오 채널 정보 조회 API를 연동한 Pull Request입니다.

### 📃 작업 사항

- [x] 서버로부터 라디오 채널 정보 데이터를 받아오는 `useFetchChannel` 커스텀 훅 생성
- [x] 선택한 채널 id값 `selectedChannelId` 전역 상태로 관리
- [x] `selectedChannelId` 전역 상태와 `useFetchChannel` 커스텀 훅 `ChannelPlayer` 컴포넌트에 연결
- [x] 채널 목록에 채널을 클릭했을 경우 `ChannelPlayer`로 이동하는 `useChannelNavigation` 커스텀 훅 생성

### 💡 참고 사항

기획의 변경으로 `/channel/:id`에서 `/channel-player`로 url이 변경되어 선택한 채널 id값을 ChannelPlayer 컴포넌트에서 알기 위해 `selectedChannelId`라는 전역 상태를 만들어 관리했습니다.

Home 컴포넌트에서 채널 목록에 채널을 클릭했을 경우 `ChannelPlayer`로 이동하는 함수를 만들면 Home -> FavoriteChannelList -> FavoriteChannelListItem 으로 불필요한 props drilling이 일어나게 됩니다. 따라서, props drilling을 해결하기 위해 `useChannelNavigation` 커스텀 훅을 생성하여 props drilling을 해결했습니다.

### 💭 리뷰 사항 반영

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
