### PR TITLE
feat: 사용자 정보 조회 API 연동

### DIFF
--- a/src/components/SettingListItem.jsx
+++ b/src/components/SettingListItem.jsx
@@ -17,11 +17,16 @@ const SettingListItem = ({ type, title, explanations }) => {
         <h2 className="text-lg font-semibold">{title}</h2>
         {explanations.map((explanation, index) =>
           index === 0 ? (
-            <p className="mt-1 mb-[-4px] text-[14px] text-[#888888]">
+            <p
+              key={index}
+              className="mt-1 mb-[-4px] text-[14px] text-[#888888]"
+            >
               {explanation}
             </p>
           ) : (
-            <p className="text-[14px] text-[#888888]">{explanation}</p>
+            <p key={index} className="text-[14px] text-[#888888]">
+              {explanation}
+            </p>
           )
         )}
       </div>

--- a/src/components/SettingListItem.jsx
+++ b/src/components/SettingListItem.jsx
@@ -1,6 +1,16 @@
 import ToggleButton from "@/components/ui/ToggleButton";
+import { useUserStore } from "@/store/useUserStore";
 
-const SettingListItem = ({ title, explanations }) => {
+const SettingListItem = ({ type, title, explanations }) => {
+  const { settings, setUserSettings } = useUserStore();
+
+  const handleToggle = () => {
+    setUserSettings({
+      ...settings,
+      [type]: !settings[type],
+    });
+  };
+
   return (
     <li className="my-4 flex h-[100px] w-full min-w-80 rounded-md bg-gray-100 px-4 pt-4">
       <div className="w-[272px]">
@@ -16,7 +26,7 @@ const SettingListItem = ({ title, explanations }) => {
         )}
       </div>
       <div className="my-auto ml-auto">
-        <ToggleButton />
+        <ToggleButton checked={settings[type]} onToggle={handleToggle} />
       </div>
     </li>
   );

--- a/src/components/ui/ToggleButton.jsx
+++ b/src/components/ui/ToggleButton.jsx
@@ -1,5 +1,3 @@
-import { useState } from "react";
-
 import Button from "@/components/ui/Button";
 
 const toggleSize = {
@@ -15,25 +13,19 @@ const toggleSize = {
   },
 };
 
-const ToggleButton = ({ size = "m" }) => {
-  const [isToggled, setIsToggled] = useState(false);
-
-  const toggleSwitch = () => {
-    setIsToggled((prev) => !prev);
-  };
-
+const ToggleButton = ({ size = "m", checked, onToggle }) => {
   const { buttonSize, thumbSize, activeTranslate } = toggleSize[size];
 
   return (
     <Button
       className={`relative cursor-pointer rounded-full transition-colors duration-200 ${
-        isToggled ? "bg-black" : "bg-neutral-300"
+        checked ? "bg-black" : "bg-neutral-300"
       } ${buttonSize}`}
-      onClick={toggleSwitch}
+      onClick={onToggle}
     >
       <div
         className={`absolute top-1 left-1 rounded-full bg-white duration-400 ${
-          isToggled ? activeTranslate : "translate-x-0"
+          checked ? activeTranslate : "translate-x-0"
         } ${thumbSize}`}
       />
     </Button>

--- a/src/hooks/useUserProfile.jsx
+++ b/src/hooks/useUserProfile.jsx
@@ -1,0 +1,30 @@
+import axios from "axios";
+import { useEffect } from "react";
+
+import { useUserStore } from "@/store/useUserStore";
+
+const useUserProfile = () => {
+  const { setUserSettings } = useUserStore();
+
+  useEffect(() => {
+    const initUserProfile = async () => {
+      const storedId = localStorage.getItem("userId");
+      if (!storedId) {
+        return;
+      }
+
+      try {
+        const response = await axios.get(
+          `${import.meta.env.VITE_API_URL}/users/${storedId}`
+        );
+        const { isAdDetect, isReturnChannel } = response.data;
+        setUserSettings({ isAdDetect, isReturnChannel });
+      } catch (error) {
+        console.error("fetch user profile failed: ", error);
+      }
+    };
+    initUserProfile();
+  }, [setUserSettings]);
+};
+
+export default useUserProfile;

--- a/src/hooks/useUserProfile.jsx
+++ b/src/hooks/useUserProfile.jsx
@@ -8,14 +8,14 @@ const useUserProfile = () => {
 
   useEffect(() => {
     const initUserProfile = async () => {
-      const storedId = localStorage.getItem("userId");
-      if (!storedId) {
+      const userId = localStorage.getItem("userId");
+      if (!userId) {
         return;
       }
 
       try {
         const response = await axios.get(
-          `${import.meta.env.VITE_API_URL}/users/${storedId}`
+          `${import.meta.env.VITE_API_URL}/users/${userId}`
         );
         const { isAdDetect, isReturnChannel } = response.data;
         setUserSettings({ isAdDetect, isReturnChannel });

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -1,5 +1,6 @@
 import SettingListItem from "@/components/SettingListItem";
 import TabBar from "@/components/TabBar";
+import useUserProfile from "@/hooks/useUserProfile";
 
 const settingList = [
   {
@@ -18,6 +19,8 @@ const settingList = [
 ];
 
 const Settings = () => {
+  useUserProfile();
+
   return (
     <>
       <TabBar />

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -29,6 +29,7 @@ const Settings = () => {
           {settingList.map(({ type, title, explanations }) => (
             <SettingListItem
               key={type}
+              type={type}
               title={title}
               explanations={explanations}
             />

--- a/src/store/useUserStore.js
+++ b/src/store/useUserStore.js
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+export const useUserStore = create((set) => ({
+  settings: {
+    isAdDetect: true,
+    isReturnChannel: false,
+  },
+  interestChannels: [],
+
+  setUserSettings: ({ isAdDetect, isReturnChannel }) =>
+    set({ settings: { isAdDetect, isReturnChannel } }),
+  setInterestChannels: (interestChannels) => set({ interestChannels }),
+}));

--- a/src/store/useUserStore.js
+++ b/src/store/useUserStore.js
@@ -5,9 +5,7 @@ export const useUserStore = create((set) => ({
     isAdDetect: true,
     isReturnChannel: false,
   },
-  interestChannels: [],
 
   setUserSettings: ({ isAdDetect, isReturnChannel }) =>
     set({ settings: { isAdDetect, isReturnChannel } }),
-  setInterestChannels: (interestChannels) => set({ interestChannels }),
 }));


### PR DESCRIPTION
### ✨ 이슈 번호 

- #52 

### 📌 설명 

- /users/{userId} API를 호출하여 사용자 정보를 조회하는 Pull Request입니다.
- 응답으로 받은 광고 감지 설정, 채널 복귀 설정 값을 zustand 상태에 저장합니다.

### 📃 작업 사항

- [X] 사용자 정보 조회 API (/users/{userId}) 연동
- [X]  localStorage에서 userId를 가져와 API 요청 수행
- [X]  API 응답 값 중 광고 감지 설정(isAdDetect), 채널 복귀 설정(isReturnChannel) 추출하여 zustand 상태에 저장
- [X] 토글 변경 시 zustand 상태 업데이트 되도록 수정


### 💭 리뷰 사항 반영 


### ✅ Pull Request 체크 사항

- [X] 가장 최신 브랜치를 pull 하였습니다.
- [X] base 브랜치명을 확인하였습니다.
- [X] 코드 컨벤션을 모두 확인하였습니다.
- [X] 브랜치명을 확인하였습니다.
