### PR TITLE
feat: 사용자 설정 변경 API 연동

### DIFF
--- a/src/components/SettingListItem.jsx
+++ b/src/components/SettingListItem.jsx
@@ -1,14 +1,13 @@
 import ToggleButton from "@/components/ui/ToggleButton";
+import useUpdateSetting from "@/hooks/useUpdateSetting";
 import { useUserStore } from "@/store/useUserStore";
 
 const SettingListItem = ({ type, title, explanations }) => {
-  const { settings, setUserSettings } = useUserStore();
+  const { settings } = useUserStore();
+  const updateSetting = useUpdateSetting(type);
 
   const handleToggle = () => {
-    setUserSettings({
-      ...settings,
-      [type]: !settings[type],
-    });
+    updateSetting();
   };
 
   return (

--- a/src/hooks/useUpdateSetting.jsx
+++ b/src/hooks/useUpdateSetting.jsx
@@ -1,0 +1,34 @@
+import axios from "axios";
+
+import { useUserStore } from "@/store/useUserStore";
+
+const useUpdateSetting = (type) => {
+  const { settings, setUserSettings } = useUserStore();
+
+  const updateSetting = async () => {
+    const userId = localStorage.getItem("userId");
+    if (!userId) {
+      return;
+    }
+
+    const updatedSettings = {
+      ...settings,
+      [type]: !settings[type],
+    };
+
+    try {
+      await axios.put(
+        `${import.meta.env.VITE_API_URL}/users/${userId}/settings`,
+        updatedSettings
+      );
+
+      setUserSettings(updatedSettings);
+    } catch (error) {
+      console.error("setting change failed", error);
+    }
+  };
+
+  return updateSetting;
+};
+
+export default useUpdateSetting;

--- a/src/hooks/useUpdateSetting.jsx
+++ b/src/hooks/useUpdateSetting.jsx
@@ -21,7 +21,6 @@ const useUpdateSetting = (type) => {
         `${import.meta.env.VITE_API_URL}/users/${userId}/settings`,
         updatedSettings
       );
-
       setUserSettings(updatedSettings);
     } catch (error) {
       console.error("setting change failed", error);


### PR DESCRIPTION
### ✨ 이슈 번호

- #57 

### 📌 설명

설정 변경 요청 후 서버 응답에 따라 설정 변경 기능을 구현한 Pull Request입니다.

### 📃 작업 사항

- [x]  설정 변경 요청 후 서버 응답에 따라 설정 변경을 진행한다.
  - [x]  서버의 응답이 200일 때, 설정이 ON에서 OFF 또는 OFF에서 ON으로 변경되고, UI 또한 변경된다.
  - [x]  서버의 응답이 200이 아닐 때, 설정은 변경되지 않으며 UI 또한 변경되지 않는다.

### 💡 참고 사항 

API 요청 및 응답 이후 상태 업데이트를 `useUpdateSetting` 커스텀 훅이 담당하는게 맞는 것 같아 기존 `SettingList`에 있던 `setUserSettings`를 제거했습니다.

실제 동작 화면

![image](https://github.com/user-attachments/assets/e811c0a7-c45f-4ed3-8183-f3f2cfb57077)

![image](https://github.com/user-attachments/assets/854e4d42-e60b-4520-992b-b866d5d9bd37)

![image](https://github.com/user-attachments/assets/2a5c94c9-f793-47e5-84de-5d48098e81fb)

### 💭 리뷰 사항 반영

- [x] `setUserSettings(updatedSettings);` 코드 앞 개행 제거

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
