### PR TITLE
feat: 광고 제보 등록 API 연동

### DIFF
--- a/src/components/AdReportModal.jsx
+++ b/src/components/AdReportModal.jsx
@@ -3,30 +3,12 @@ import { useState } from "react";
 import ToggleCheckbox from "@/components/ToggleCheckbox";
 import Button from "@/components/ui/Button";
 import Modal from "@/components/ui/Modal";
+import {
+  AD_REPORT_TYPES,
+  AD_REPORT_OPTIONS,
+} from "@/constants/adReportOptions";
 import useSubmitAdReport from "@/hooks/useSubmitAdReport";
 import useUserId from "@/hooks/useUserId";
-
-const AD_REPORT_TYPES = {
-  AD: "ad",
-  NOT_AD: "not-ad",
-};
-
-const AD_REPORT_OPTIONS = {
-  [AD_REPORT_TYPES.AD]: {
-    parentOption: "광고입니다",
-    childrenOptions: [
-      { id: "move-other", label: "다른 채널로 이동하기" },
-      { id: "ad-stay-current", label: "현재 채널 계속 시청하기" },
-    ],
-  },
-  [AD_REPORT_TYPES.NOT_AD]: {
-    parentOption: "광고가 아닌데 채널이 이동했습니다",
-    childrenOptions: [
-      { id: "move-previous", label: "다른 채널로 이동하기" },
-      { id: "not-ad-stay-current", label: "현재 채널 계속 시청하기" },
-    ],
-  },
-};
 
 const AdReportModal = ({
   isChannelChanged,

--- a/src/components/AdReportModal.jsx
+++ b/src/components/AdReportModal.jsx
@@ -95,6 +95,7 @@ const AdReportModal = ({
         <Button
           className="flex h-[35px] w-[75px] items-center justify-center rounded-md bg-[#5B4DFF] px-4 py-2 text-[16px] text-white hover:bg-[#4F46E5]"
           onClick={handleSubmit}
+          disabled={!selectedOption || !selectedChildId}
         >
           확인
         </Button>

--- a/src/components/AdReportModal.jsx
+++ b/src/components/AdReportModal.jsx
@@ -28,7 +28,12 @@ const AD_REPORT_OPTIONS = {
   },
 };
 
-const AdReportModal = ({ isChannelChanged, channelId, detectedAdPhrase }) => {
+const AdReportModal = ({
+  isChannelChanged,
+  channelId,
+  detectedAdPhrase,
+  onClose,
+}) => {
   const [selectedOption, setSelectedOption] = useState(null);
 
   const submitAdReport = useSubmitAdReport();
@@ -56,6 +61,8 @@ const AdReportModal = ({ isChannelChanged, channelId, detectedAdPhrase }) => {
       detectedAdPhrase,
       channelId,
     });
+
+    onClose();
   };
 
   return (

--- a/src/components/AdReportModal.jsx
+++ b/src/components/AdReportModal.jsx
@@ -35,6 +35,7 @@ const AdReportModal = ({
   onClose,
 }) => {
   const [selectedOption, setSelectedOption] = useState(null);
+  const [selectedChildId, setSelectedChildId] = useState(null);
 
   const submitAdReport = useSubmitAdReport();
   const userId = useUserId();
@@ -80,6 +81,8 @@ const AdReportModal = ({
                 onSelect={() => toggleParentOption(key)}
                 parentOption={parentOption}
                 childrenOptions={childrenOptions}
+                selectedChildId={selectedChildId}
+                onChangeChild={setSelectedChildId}
               />
             )
           )}

--- a/src/components/AdReportModal.jsx
+++ b/src/components/AdReportModal.jsx
@@ -34,8 +34,8 @@ const AdReportModal = ({
   detectedAdPhrase,
   onClose,
 }) => {
-  const [selectedOption, setSelectedOption] = useState(null);
-  const [selectedChildId, setSelectedChildId] = useState(null);
+  const [selectedParentOption, setSelectedParentOption] = useState(null);
+  const [selectedChildOption, setSelectedChildOption] = useState(null);
 
   const submitAdReport = useSubmitAdReport();
   const userId = useUserId();
@@ -50,11 +50,11 @@ const AdReportModal = ({
     }
   );
   const toggleParentOption = (option) => {
-    setSelectedOption((prev) => (prev === option ? null : option));
+    setSelectedParentOption((prev) => (prev === option ? null : option));
   };
 
   const handleSubmit = async () => {
-    const isAd = selectedOption === AD_REPORT_TYPES.AD;
+    const isAd = selectedParentOption === AD_REPORT_TYPES.AD;
 
     await submitAdReport({
       userId: Number(userId),
@@ -77,12 +77,12 @@ const AdReportModal = ({
             ([key, { parentOption, childrenOptions }]) => (
               <ToggleCheckbox
                 key={key}
-                isSelected={selectedOption === key}
+                isSelected={selectedParentOption === key}
                 onSelect={() => toggleParentOption(key)}
                 parentOption={parentOption}
                 childrenOptions={childrenOptions}
-                selectedChildId={selectedChildId}
-                onChangeChild={setSelectedChildId}
+                selectedSubOptionId={selectedChildOption}
+                onSelectSubOption={setSelectedChildOption}
               />
             )
           )}
@@ -98,7 +98,7 @@ const AdReportModal = ({
         <Button
           className="flex h-[35px] w-[75px] items-center justify-center rounded-md bg-[#5B4DFF] px-4 py-2 text-[16px] text-white hover:bg-[#4F46E5]"
           onClick={handleSubmit}
-          disabled={!selectedOption || !selectedChildId}
+          disabled={!selectedParentOption || !selectedChildOption}
         >
           확인
         </Button>

--- a/src/components/AdReportModal.jsx
+++ b/src/components/AdReportModal.jsx
@@ -3,6 +3,8 @@ import { useState } from "react";
 import ToggleCheckbox from "@/components/ToggleCheckbox";
 import Button from "@/components/ui/Button";
 import Modal from "@/components/ui/Modal";
+import useSubmitAdReport from "@/hooks/useSubmitAdReport";
+import useUserId from "@/hooks/useUserId";
 
 const AD_REPORT_TYPES = {
   AD: "ad",
@@ -26,8 +28,11 @@ const AD_REPORT_OPTIONS = {
   },
 };
 
-const AdReportModal = ({ isChannelChanged }) => {
+const AdReportModal = ({ isChannelChanged, channelId, detectedAdPhrase }) => {
   const [selectedOption, setSelectedOption] = useState(null);
+
+  const submitAdReport = useSubmitAdReport();
+  const userId = useUserId();
 
   const availableReportOptions = Object.entries(AD_REPORT_OPTIONS).filter(
     ([key]) => {
@@ -40,6 +45,17 @@ const AdReportModal = ({ isChannelChanged }) => {
   );
   const toggleParentOption = (option) => {
     setSelectedOption((prev) => (prev === option ? null : option));
+  };
+
+  const handleSubmit = async () => {
+    const isAd = selectedOption === AD_REPORT_TYPES.AD;
+
+    await submitAdReport({
+      userId: Number(userId),
+      isAd,
+      detectedAdPhrase,
+      channelId,
+    });
   };
 
   return (
@@ -66,7 +82,10 @@ const AdReportModal = ({ isChannelChanged }) => {
         <Button className="flex h-[35px] w-[75px] items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-[16px] text-black hover:bg-gray-100">
           취소
         </Button>
-        <Button className="flex h-[35px] w-[75px] items-center justify-center rounded-md bg-[#5B4DFF] px-4 py-2 text-[16px] text-white hover:bg-[#4F46E5]">
+        <Button
+          className="flex h-[35px] w-[75px] items-center justify-center rounded-md bg-[#5B4DFF] px-4 py-2 text-[16px] text-white hover:bg-[#4F46E5]"
+          onClick={handleSubmit}
+        >
           확인
         </Button>
       </div>

--- a/src/components/AdReportModal.jsx
+++ b/src/components/AdReportModal.jsx
@@ -89,7 +89,10 @@ const AdReportModal = ({
         </div>
       </div>
       <div className="mt-[25px] flex w-full justify-end gap-x-2">
-        <Button className="flex h-[35px] w-[75px] items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-[16px] text-black hover:bg-gray-100">
+        <Button
+          className="flex h-[35px] w-[75px] items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-[16px] text-black hover:bg-gray-100"
+          onClick={onClose}
+        >
           취소
         </Button>
         <Button

--- a/src/components/ToggleCheckbox.jsx
+++ b/src/components/ToggleCheckbox.jsx
@@ -5,16 +5,16 @@ const ToggleCheckbox = ({
   onSelect,
   parentOption,
   childrenOptions,
-  selectedChildId,
-  onChangeChild,
+  selectedSubOptionId,
+  onSelectSubOption,
 }) => {
   const handleParentClick = () => {
     onSelect();
-    onChangeChild(null);
+    onSelectSubOption(null);
   };
 
   const toggleChildOption = (id) => {
-    onChangeChild(selectedChildId === id ? null : id);
+    onSelectSubOption(selectedSubOptionId === id ? null : id);
   };
 
   return (
@@ -32,7 +32,7 @@ const ToggleCheckbox = ({
           {childrenOptions.map(({ id, label }) => (
             <Checkbox
               key={id}
-              checked={selectedChildId === id}
+              checked={selectedSubOptionId === id}
               onChange={() => toggleChildOption(id)}
               labelClassName="text-[16px] whitespace-nowrap"
               inputClassName="h-[18px] min-h-[18px] w-[18px] min-w-[18px]"

--- a/src/components/ToggleCheckbox.jsx
+++ b/src/components/ToggleCheckbox.jsx
@@ -1,5 +1,3 @@
-import { useState } from "react";
-
 import Checkbox from "@/components/ui/Checkbox";
 
 const ToggleCheckbox = ({
@@ -7,16 +5,16 @@ const ToggleCheckbox = ({
   onSelect,
   parentOption,
   childrenOptions,
+  selectedChildId,
+  onChangeChild,
 }) => {
-  const [selectedChildId, setSelectedChildId] = useState(null);
-
   const handleParentClick = () => {
     onSelect();
-    setSelectedChildId(null);
+    onChangeChild(null);
   };
 
   const toggleChildOption = (id) => {
-    setSelectedChildId((prev) => (prev === id ? null : id));
+    onChangeChild(selectedChildId === id ? null : id);
   };
 
   return (

--- a/src/components/header/ReportHeader.jsx
+++ b/src/components/header/ReportHeader.jsx
@@ -25,7 +25,9 @@ const ReportHeader = () => {
         <AdReportIcon />
         광고 제보하기
       </button>
-      {isAdReportModalOpen && <AdReportModal />}
+      {isAdReportModalOpen && (
+        <AdReportModal onClose={() => setIsAdReportModalOpen(false)} />
+      )}
     </div>
   );
 };

--- a/src/components/ui/Button.jsx
+++ b/src/components/ui/Button.jsx
@@ -1,6 +1,6 @@
-const Button = ({ children, className, onClick }) => {
+const Button = ({ children, className, onClick, disabled }) => {
   return (
-    <button className={className} onClick={onClick}>
+    <button className={className} onClick={onClick} disabled={disabled}>
       {children}
     </button>
   );

--- a/src/constants/adReportOptions.js
+++ b/src/constants/adReportOptions.js
@@ -1,0 +1,21 @@
+export const AD_REPORT_TYPES = {
+  AD: "ad",
+  NOT_AD: "not-ad",
+};
+
+export const AD_REPORT_OPTIONS = {
+  [AD_REPORT_TYPES.AD]: {
+    parentOption: "광고입니다",
+    childrenOptions: [
+      { id: "move-other", label: "다른 채널로 이동하기" },
+      { id: "ad-stay-current", label: "현재 채널 계속 시청하기" },
+    ],
+  },
+  [AD_REPORT_TYPES.NOT_AD]: {
+    parentOption: "광고가 아닌데 채널이 이동했습니다",
+    childrenOptions: [
+      { id: "move-previous", label: "다른 채널로 이동하기" },
+      { id: "not-ad-stay-current", label: "현재 채널 계속 시청하기" },
+    ],
+  },
+};

--- a/src/hooks/useSubmitAdReport.jsx
+++ b/src/hooks/useSubmitAdReport.jsx
@@ -17,6 +17,7 @@ const useSubmitAdReport = () => {
       console.error("fetch ad report failed:", error);
     }
   };
+
   return reportAd;
 };
 

--- a/src/hooks/useSubmitAdReport.jsx
+++ b/src/hooks/useSubmitAdReport.jsx
@@ -1,0 +1,23 @@
+import axios from "axios";
+
+const useSubmitAdReport = () => {
+  const reportAd = async ({ userId, isAd, detectedAdPhrase, channelId }) => {
+    try {
+      const { data } = await axios.post(
+        `${import.meta.env.VITE_API_URL}/reports`,
+        {
+          userId,
+          isAd,
+          detectedAdPhrase,
+          channelId,
+        }
+      );
+      return data;
+    } catch (error) {
+      console.error("fetch ad report failed:", error);
+    }
+  };
+  return reportAd;
+};
+
+export default useSubmitAdReport;


### PR DESCRIPTION
### ✨ 이슈 번호 

- #60 

### 📌 설명

- 광고 제보 모달에서 사용자 선택에 따라 서버에 광고 제보 요청을 보내는 기능을 구현한 Pull Request입니다.
- 선택된 옵션과 하위 항목을 기반으로 유효한 경우에만 요청이 전송되며, 요청 이후 모달이 닫히도록 수정했습니다.

### 📃 작업 사항

- [x] 광고 제보 등록 API 연동 훅 (`useSubmitAdReport`) 구현
- [x] 모달 내 옵션 선택 상태 관리 및 전송 로직 추가
- [x] 옵션 미선택 시 버튼 비활성화 처리
- [x] 확인 버튼 클릭 시 모달 닫힘 처리 추

### 💡 참고 사항 (선택)

- 하위 옵션(`ToggleCheckbox`)의 선택 상태를 상위 컴포넌트에서 관리하도록 상태를 끌어올렸습니다.

### 💭 리뷰 사항 반영 

- [x] 옵션 선택 관련 변수 및 prop 네이밍 명확화
- [x] 광고 제보 타입 및 옵션 상수 파일로 분리
- [x] return 구문 앞에 개행 추가

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
