### PR TITLE
fix: Cannot destructure property 'name' of 'useChannelInfo(...)' as it is null 문제 해결

### DIFF
--- a/src/pages/ChannelPlayer.jsx
+++ b/src/pages/ChannelPlayer.jsx
@@ -11,9 +11,15 @@ import controlStreamingPlayback from "@/utils/playControl";
 
 const ChannelPlayer = ({ isChannelChanged }) => {
   const selectedChannelId = useChannelStore((state) => state.selectedChannelId);
-  const { name, url, logoUrl } = useChannelInfo(selectedChannelId);
+  const channelInfo = useChannelInfo(selectedChannelId);
   const [isPlaying, setIsPlaying] = useState(false);
   const videoId = useRef(null);
+
+  if (!selectedChannelId || !channelInfo) {
+    return null;
+  }
+
+  const { name, url, logoUrl } = channelInfo;
 
   const buttonLabel = isChannelChanged
     ? SETTING_TITLES[SETTING_TYPES.RETURN_CHANNEL]


### PR DESCRIPTION
### ✨ 이슈 번호 66

- #66 

### 📌 설명

Home 페이지에서 라디오 채널 목록의 라디오 채널을 클릭했을 때, /channel-player url로 이동하고 Cannot destructure property 'name' of 'useChannelInfo(...)' as it is null 이라는 에러가 화면에 나오고 서버로부터 라디오 채널 정보를 받아오는 API 요청 또한 진행되고 있지 않는 에러를 해결한 Pull Request 입니다.

### 📃 작업 사항

- [x] Cannot destructure property 'name' of 'useChannelInfo(...)' as it is null 문제 해결

### 💡 참고 사항

데이터를 받아오기 전에 구조 분해 할당을 진행해서 생긴 버그이므로 아래와 같이 가드 조건을 설정하여 해결할 수 있습니다.

### 💭 리뷰 사항 반영

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
