### PR TITLE
refactor: 사용자 정보 조회 로직 통합

### DIFF
--- a/src/hooks/useUserData.jsx
+++ b/src/hooks/useUserData.jsx
@@ -1,4 +1,3 @@
-import useChannels from "@/hooks/useChannels";
 import useInterestChannels from "@/hooks/useInterestChannels";
 import useUserId from "@/hooks/useUserId";
 import useUserProfile from "@/hooks/useUserProfile";
@@ -6,7 +5,6 @@ import useUserProfile from "@/hooks/useUserProfile";
 const useUserData = () => {
   const userId = useUserId();
 
-  useChannels();
   useInterestChannels(userId);
   useUserProfile(userId);
 };

--- a/src/hooks/useUserData.jsx
+++ b/src/hooks/useUserData.jsx
@@ -1,0 +1,14 @@
+import useChannels from "@/hooks/useChannels";
+import useInterestChannels from "@/hooks/useInterestChannels";
+import useUserId from "@/hooks/useUserId";
+import useUserProfile from "@/hooks/useUserProfile";
+
+const useUserData = () => {
+  const userId = useUserId();
+
+  useChannels();
+  useInterestChannels(userId);
+  useUserProfile(userId);
+};
+
+export default useUserData;

--- a/src/hooks/useUserProfile.jsx
+++ b/src/hooks/useUserProfile.jsx
@@ -3,12 +3,11 @@ import { useEffect } from "react";
 
 import { useUserStore } from "@/store/useUserStore";
 
-const useUserProfile = () => {
+const useUserProfile = (userId) => {
   const { setUserSettings } = useUserStore();
 
   useEffect(() => {
     const initUserProfile = async () => {
-      const userId = localStorage.getItem("userId");
       if (!userId) {
         return;
       }
@@ -24,7 +23,7 @@ const useUserProfile = () => {
       }
     };
     initUserProfile();
-  }, [setUserSettings]);
+  }, [userId, setUserSettings]);
 };
 
 export default useUserProfile;

--- a/src/hooks/useUserProfile.jsx
+++ b/src/hooks/useUserProfile.jsx
@@ -7,11 +7,11 @@ const useUserProfile = (userId) => {
   const { setUserSettings } = useUserStore();
 
   useEffect(() => {
-    const initUserProfile = async () => {
-      if (!userId) {
-        return;
-      }
+    if (!userId) {
+      return;
+    }
 
+    const initUserProfile = async () => {
       try {
         const response = await axios.get(
           `${import.meta.env.VITE_API_URL}/users/${userId}`

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -3,9 +3,11 @@ import ChannelSection from "@/components/ChannelSection";
 import FavoriteChannelList from "@/components/FavoriteChannelList";
 import TabBar from "@/components/TabBar";
 import useCategorizeChannels from "@/hooks/useCategorizeChannels";
+import useChannels from "@/hooks/useChannels";
 import useUserData from "@/hooks/useUserData";
 
 const Home = () => {
+  useChannels();
   useUserData();
   const [favoriteChannelList, otherChannelList] = useCategorizeChannels();
 

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -3,14 +3,10 @@ import ChannelSection from "@/components/ChannelSection";
 import FavoriteChannelList from "@/components/FavoriteChannelList";
 import TabBar from "@/components/TabBar";
 import useCategorizeChannels from "@/hooks/useCategorizeChannels";
-import useChannels from "@/hooks/useChannels";
-import useInterestChannels from "@/hooks/useInterestChannels";
-import useUserId from "@/hooks/useUserId";
+import useUserData from "@/hooks/useUserData";
 
 const Home = () => {
-  useChannels();
-  const userId = useUserId();
-  useInterestChannels(userId);
+  useUserData();
   const [favoriteChannelList, otherChannelList] = useCategorizeChannels();
 
   return (

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -1,6 +1,5 @@
 import SettingListItem from "@/components/SettingListItem";
 import TabBar from "@/components/TabBar";
-import useUserProfile from "@/hooks/useUserProfile";
 
 const settingList = [
   {
@@ -19,8 +18,6 @@ const settingList = [
 ];
 
 const Settings = () => {
-  useUserProfile();
-
   return (
     <>
       <TabBar />


### PR DESCRIPTION
### ✨ 이슈 번호

- #68

### 📌 설명

현재 사용자의 즐겨찾기 채널 목록 정보는 Home 컴포넌트에 진입했을 때, 설정 정보는 Settings 컴포넌트에 진입했을 때 가져오고 있습니다. 우리의 서비스는 ChannelPlayer 컴포넌트에서 설정을 변경할 수 있고 사용자가 Home 컴포넌트에서 Settings 컴포넌트에 진입하지 않고 ChannelPlayer 컴포넌트에 진입하면 설정을 불러오지 않을 수 있는 에러가 발생할 수 있습니다. 이를 사전에 방지하기 위해 메인 페이지인 Home 컴포넌트에 진입할 때 사용자의 정보를 모두 받아올 수 있도록 사용자 정보 조회 로직 통합 작업을 진행한 Pull Request입니다.

### 📃 작업 사항

- [x] 사용자 정보 조회 로직 통합
- [x] 통합하며 제거해도 되는 코드들 제거

### 💡 참고 사항

useUserProfile은 기존에는 useUserProfile 훅 내에서 localStorage에서 직접 userId를 가져왔으나, 이를 외부에서 주입받도록 변경하여 훅의 재사용을 개선했습니다.

### 💭 리뷰 사항 반영

- [x] `useUserData`에서 `useChannels` 제거

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
