### PR TITLE
feat: 설정 변경 로직 수정 및 라디오 채널 페이지 설정 변경 기능 연동

### DIFF
--- a/src/components/SettingListItem.jsx
+++ b/src/components/SettingListItem.jsx
@@ -1,4 +1,5 @@
 import ToggleButton from "@/components/ui/ToggleButton";
+import { SETTING_TYPES } from "@/constants/settingOptions";
 import useUpdateSetting from "@/hooks/useUpdateSetting";
 import { useUserStore } from "@/store/useUserStore";
 
@@ -33,7 +34,9 @@ const SettingListItem = ({ type, title, explanations }) => {
         <ToggleButton
           checked={settings[type]}
           onToggle={handleToggle}
-          disabled={type === "isReturnChannel" && !settings.isAdDetect}
+          disabled={
+            type === SETTING_TYPES.RETURN_CHANNEL && !settings.isAdDetect
+          }
         />
       </div>
     </li>

--- a/src/components/SettingListItem.jsx
+++ b/src/components/SettingListItem.jsx
@@ -30,7 +30,11 @@ const SettingListItem = ({ type, title, explanations }) => {
         )}
       </div>
       <div className="my-auto ml-auto">
-        <ToggleButton checked={settings[type]} onToggle={handleToggle} />
+        <ToggleButton
+          checked={settings[type]}
+          onToggle={handleToggle}
+          disabled={type === "isReturnChannel" && !settings.isAdDetect}
+        />
       </div>
     </li>
   );

--- a/src/components/ui/ToggleButton.jsx
+++ b/src/components/ui/ToggleButton.jsx
@@ -26,7 +26,7 @@ const ToggleButton = ({ size = "m", checked, onToggle, disabled = false }) => {
             ? "bg-black"
             : "bg-neutral-300"
       } ${buttonSize}`}
-      onClick={disabled ? undefined : onToggle}
+      onClick={onToggle}
     >
       <div
         className={`absolute top-1 left-1 rounded-full bg-white duration-400 ${

--- a/src/components/ui/ToggleButton.jsx
+++ b/src/components/ui/ToggleButton.jsx
@@ -13,15 +13,20 @@ const toggleSize = {
   },
 };
 
-const ToggleButton = ({ size = "m", checked, onToggle }) => {
+const ToggleButton = ({ size = "m", checked, onToggle, disabled = false }) => {
   const { buttonSize, thumbSize, activeTranslate } = toggleSize[size];
 
   return (
     <Button
+      disabled={disabled}
       className={`relative cursor-pointer rounded-full transition-colors duration-200 ${
-        checked ? "bg-black" : "bg-neutral-300"
+        disabled
+          ? "cursor-not-allowed bg-neutral-200"
+          : checked
+            ? "bg-black"
+            : "bg-neutral-300"
       } ${buttonSize}`}
-      onClick={onToggle}
+      onClick={disabled ? undefined : onToggle}
     >
       <div
         className={`absolute top-1 left-1 rounded-full bg-white duration-400 ${

--- a/src/constants/settingOptions.js
+++ b/src/constants/settingOptions.js
@@ -3,6 +3,11 @@ export const SETTING_TYPES = {
   RETURN_CHANNEL: "RETURN_CHANNEL",
 };
 
+export const SETTING_CAMEL_TYPES = {
+  [SETTING_TYPES.AD_DETECT]: "isAdDetect",
+  [SETTING_TYPES.RETURN_CHANNEL]: "isReturnChannel",
+};
+
 export const SETTING_TITLES = {
   [SETTING_TYPES.AD_DETECT]: "광고 감지",
   [SETTING_TYPES.RETURN_CHANNEL]: "기존 채널로 이동",

--- a/src/constants/settingOptions.js
+++ b/src/constants/settingOptions.js
@@ -1,11 +1,6 @@
 export const SETTING_TYPES = {
-  AD_DETECT: "AD_DETECT",
-  RETURN_CHANNEL: "RETURN_CHANNEL",
-};
-
-export const SETTING_CAMEL_TYPES = {
-  [SETTING_TYPES.AD_DETECT]: "isAdDetect",
-  [SETTING_TYPES.RETURN_CHANNEL]: "isReturnChannel",
+  AD_DETECT: "isAdDetect",
+  RETURN_CHANNEL: "isReturnChannel",
 };
 
 export const SETTING_TITLES = {

--- a/src/constants/settingOptions.js
+++ b/src/constants/settingOptions.js
@@ -7,3 +7,14 @@ export const SETTING_TITLES = {
   [SETTING_TYPES.AD_DETECT]: "광고 감지",
   [SETTING_TYPES.RETURN_CHANNEL]: "기존 채널로 이동",
 };
+
+export const SETTING_EXPLANATIONS = {
+  [SETTING_TYPES.AD_DETECT]: [
+    "현재 채널에서 광고를 자동으로 감지합니다.",
+    "광고가 감지되면 다른 채널로 이동합니다.",
+  ],
+  [SETTING_TYPES.RETURN_CHANNEL]: [
+    "이전 채널의 광고가 종료되면",
+    "자동으로 복귀합니다.",
+  ],
+};

--- a/src/hooks/useUpdateSetting.jsx
+++ b/src/hooks/useUpdateSetting.jsx
@@ -1,5 +1,6 @@
 import axios from "axios";
 
+import { SETTING_TYPES } from "@/constants/settingOptions";
 import { useUserStore } from "@/store/useUserStore";
 
 const useUpdateSetting = (type) => {
@@ -16,7 +17,7 @@ const useUpdateSetting = (type) => {
       [type]: !settings[type],
     };
 
-    if (type === "isAdDetect" && !updatedSettings.isAdDetect) {
+    if (type === SETTING_TYPES.AD_DETECT && !updatedSettings.isAdDetect) {
       updatedSettings.isReturnChannel = false;
     }
 

--- a/src/hooks/useUpdateSetting.jsx
+++ b/src/hooks/useUpdateSetting.jsx
@@ -16,6 +16,10 @@ const useUpdateSetting = (type) => {
       [type]: !settings[type],
     };
 
+    if (type === "isAdDetect" && !updatedSettings.isAdDetect) {
+      updatedSettings.isReturnChannel = false;
+    }
+
     try {
       await axios.put(
         `${import.meta.env.VITE_API_URL}/users/${userId}/settings`,

--- a/src/pages/ChannelPlayer.jsx
+++ b/src/pages/ChannelPlayer.jsx
@@ -4,11 +4,7 @@ import MainPauseIcon from "@/assets/svgs/icon-main-pause.svg?react";
 import MainPlayIcon from "@/assets/svgs/icon-main-play.svg?react";
 import Button from "@/components/ui/Button";
 import ToggleButton from "@/components/ui/ToggleButton";
-import {
-  SETTING_TYPES,
-  SETTING_CAMEL_TYPES,
-  SETTING_TITLES,
-} from "@/constants/settingOptions";
+import { SETTING_TYPES, SETTING_TITLES } from "@/constants/settingOptions";
 import useUpdateSetting from "@/hooks/useUpdateSetting";
 import { useChannelStore } from "@/store/useChannelStore";
 import { useUserStore } from "@/store/useUserStore";
@@ -32,8 +28,8 @@ const ChannelPlayer = ({ isChannelChanged }) => {
     : SETTING_TITLES[SETTING_TYPES.AD_DETECT];
 
   const settingType = isChannelChanged
-    ? SETTING_CAMEL_TYPES[SETTING_TYPES.RETURN_CHANNEL]
-    : SETTING_CAMEL_TYPES[SETTING_TYPES.AD_DETECT];
+    ? SETTING_TYPES.RETURN_CHANNEL
+    : SETTING_TYPES.AD_DETECT;
 
   const updateSetting = useUpdateSetting(settingType);
 

--- a/src/pages/ChannelPlayer.jsx
+++ b/src/pages/ChannelPlayer.jsx
@@ -4,8 +4,14 @@ import MainPauseIcon from "@/assets/svgs/icon-main-pause.svg?react";
 import MainPlayIcon from "@/assets/svgs/icon-main-play.svg?react";
 import Button from "@/components/ui/Button";
 import ToggleButton from "@/components/ui/ToggleButton";
-import { SETTING_TYPES, SETTING_TITLES } from "@/constants/settingOptions";
+import {
+  SETTING_TYPES,
+  SETTING_CAMEL_TYPES,
+  SETTING_TITLES,
+} from "@/constants/settingOptions";
+import useUpdateSetting from "@/hooks/useUpdateSetting";
 import { useChannelStore } from "@/store/useChannelStore";
+import { useUserStore } from "@/store/useUserStore";
 import controlStreamingPlayback from "@/utils/playControl";
 
 const ChannelPlayer = ({ isChannelChanged }) => {
@@ -17,6 +23,7 @@ const ChannelPlayer = ({ isChannelChanged }) => {
     (channel) => channel.id === selectedChannelId
   );
   const videoId = useRef(null);
+  const { settings } = useUserStore();
 
   const { name, logoUrl } = channel;
 
@@ -24,9 +31,19 @@ const ChannelPlayer = ({ isChannelChanged }) => {
     ? SETTING_TITLES[SETTING_TYPES.RETURN_CHANNEL]
     : SETTING_TITLES[SETTING_TYPES.AD_DETECT];
 
+  const settingType = isChannelChanged
+    ? SETTING_CAMEL_TYPES[SETTING_TYPES.RETURN_CHANNEL]
+    : SETTING_CAMEL_TYPES[SETTING_TYPES.AD_DETECT];
+
+  const updateSetting = useUpdateSetting(settingType);
+
   const handlePlayPause = () => {
     controlStreamingPlayback(videoId, selectedChannelId, isPlaying);
     setIsPlaying((prev) => !prev);
+  };
+
+  const handleToggle = () => {
+    updateSetting();
   };
 
   return (
@@ -42,7 +59,11 @@ const ChannelPlayer = ({ isChannelChanged }) => {
         </p>
         <div className="mt-2 flex items-center gap-x-2">
           <p className="text-sm font-semibold sm:text-base">{buttonLabel}</p>
-          <ToggleButton size="s" />
+          <ToggleButton
+            size="s"
+            checked={settings[settingType]}
+            onToggle={handleToggle}
+          />
         </div>
         <video ref={videoId} className="hidden" />
         <Button className="mt-12" onClick={handlePlayPause}>

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -1,34 +1,25 @@
 import SettingListItem from "@/components/SettingListItem";
 import TabBar from "@/components/TabBar";
-
-const settingList = [
-  {
-    type: "isAdDetect",
-    title: "광고 감지",
-    explanations: [
-      "현재 채널에서 광고를 자동으로 감지합니다.",
-      "광고가 감지되면 다른 채널로 이동합니다.",
-    ],
-  },
-  {
-    type: "isReturnChannel",
-    title: "기존 채널로 이동",
-    explanations: ["이전 채널의 광고가 종료되면", "자동으로 복귀합니다."],
-  },
-];
+import {
+  SETTING_TYPES,
+  SETTING_TITLES,
+  SETTING_EXPLANATIONS,
+} from "@/constants/settingsData";
 
 const Settings = () => {
+  const settingTypes = Object.values(SETTING_TYPES);
+
   return (
     <>
       <TabBar />
       <div className="p-4">
         <ul>
-          {settingList.map(({ type, title, explanations }) => (
+          {settingTypes.map((type) => (
             <SettingListItem
               key={type}
               type={type}
-              title={title}
-              explanations={explanations}
+              title={SETTING_TITLES[type]}
+              explanations={SETTING_EXPLANATIONS[type]}
             />
           ))}
         </ul>

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -2,7 +2,6 @@ import SettingListItem from "@/components/SettingListItem";
 import TabBar from "@/components/TabBar";
 import {
   SETTING_TYPES,
-  SETTING_CAMEL_TYPES,
   SETTING_TITLES,
   SETTING_EXPLANATIONS,
 } from "@/constants/settingOptions";
@@ -18,7 +17,7 @@ const Settings = () => {
           {settingTypes.map((type) => (
             <SettingListItem
               key={type}
-              type={SETTING_CAMEL_TYPES[type]}
+              type={type}
               title={SETTING_TITLES[type]}
               explanations={SETTING_EXPLANATIONS[type]}
             />

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -5,7 +5,7 @@ import {
   SETTING_CAMEL_TYPES,
   SETTING_TITLES,
   SETTING_EXPLANATIONS,
-} from "@/constants/settingsData";
+} from "@/constants/settingOptions";
 
 const Settings = () => {
   const settingTypes = Object.values(SETTING_TYPES);

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -2,6 +2,7 @@ import SettingListItem from "@/components/SettingListItem";
 import TabBar from "@/components/TabBar";
 import {
   SETTING_TYPES,
+  SETTING_CAMEL_TYPES,
   SETTING_TITLES,
   SETTING_EXPLANATIONS,
 } from "@/constants/settingsData";
@@ -17,7 +18,7 @@ const Settings = () => {
           {settingTypes.map((type) => (
             <SettingListItem
               key={type}
-              type={type}
+              type={SETTING_CAMEL_TYPES[type]}
               title={SETTING_TITLES[type]}
               explanations={SETTING_EXPLANATIONS[type]}
             />


### PR DESCRIPTION
### ✨ 이슈 번호

- #72 

### 📌 설명

Settings에 있는 settingList를 settingOptions.js로 활용하여 리팩토링하고 설정 변경 로직을 수정하며 라디오 채널 페이지에 설정 변경 기능을 연동한 Pull Request입니다.

### 📃 작업 사항

- [x] `Settings`에 있는 `settingList`를 `settingOptions.js`로 활용하여 리팩토링
- [x] 설정 변경 로직 수정
- [x] 라디오 채널 페이지 설정 변경 기능 연동

### 💡 참고 사항

광고 감지가 `true`일 경우, 광고가 재생될 때 다른 채널로 이동되므로 기존 채널로 이동 여부를 설정할 수 있습니다. 
하지만, 광고 감지가 `false`일 경우, 광고가 재생되도 다른 채널로 이동되지 않기에 기존 채널로 이동 여부를 설정할 수 없습니다.
따라서, 광고 감지를 `true`에서 `false`로 바꾸면 기존 채널로 이동도 `true`일 경우, `false`로 바뀌어야 하며, 
광고 감지가 `false`일 때, 기존 채널로 이동 여부를 설정할 수 없어야 합니다.

### 💭 리뷰 사항 반영

- [x] `onClick`에 있던 조건문 제거

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
