### PR TITLE
feat: 광고 제보 모달에 광고 멘트 입력 필드 추가

### DIFF
--- a/src/components/AdReportModal.jsx
+++ b/src/components/AdReportModal.jsx
@@ -70,32 +70,33 @@ const AdReportModal = ({
           )}
         </div>
       </div>
-      <form className="mt-5 w-full">
+      <div className="absolute bottom-38">
         <div className="w-full">
-          <label className="block w-full text-left text-sm whitespace-nowrap text-gray-600">
+          <label className="block text-left text-sm whitespace-nowrap text-gray-600">
             📌 광고로 판단되는 멘트를 입력해주세요 (선택)
           </label>
+          <input
+            type="text"
+            placeholder="EX) '하핑하핑'"
+            className="mt-2 w-full rounded-lg border border-gray-300 px-4 py-2 transition focus:ring-2 focus:ring-blue-400 focus:outline-none"
+          />
         </div>
-        <input
-          type="text"
-          placeholder="EX) '하핑하핑'"
-          className="mt-2 w-full rounded-lg border border-gray-300 px-4 py-2 transition focus:ring-2 focus:ring-blue-400 focus:outline-none"
-        />
-      </form>
-      <div className="mt-[25px] flex w-full justify-end gap-x-2">
-        <Button
-          className="flex h-[35px] w-[75px] items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-[16px] text-black hover:bg-gray-100"
-          onClick={onClose}
-        >
-          취소
-        </Button>
-        <Button
-          className="flex h-[35px] w-[75px] items-center justify-center rounded-md bg-[#5B4DFF] px-4 py-2 text-[16px] text-white hover:bg-[#4F46E5]"
-          onClick={handleSubmit}
-          disabled={!selectedParentOption || !selectedChildOption}
-        >
-          확인
-        </Button>
+
+        <div className="mt-4 flex w-full justify-end gap-x-2">
+          <Button
+            className="flex h-[35px] w-[75px] items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-[16px] text-black hover:bg-gray-100"
+            onClick={onClose}
+          >
+            취소
+          </Button>
+          <Button
+            className="flex h-[35px] w-[75px] items-center justify-center rounded-md bg-[#5B4DFF] px-4 py-2 text-[16px] text-white hover:bg-[#4F46E5]"
+            onClick={handleSubmit}
+            disabled={!selectedParentOption || !selectedChildOption}
+          >
+            확인
+          </Button>
+        </div>
       </div>
     </Modal>
   );

--- a/src/components/AdReportModal.jsx
+++ b/src/components/AdReportModal.jsx
@@ -71,9 +71,11 @@ const AdReportModal = ({
         </div>
       </div>
       <form className="mt-5 w-full">
-        <label className="text-md block text-left text-gray-600">
-          📌광고라고 판단되는 멘트를 입력해주세요 (선택)
-        </label>
+        <div className="w-full">
+          <label className="block w-full text-left text-sm whitespace-nowrap text-gray-600">
+            📌 광고로 판단되는 멘트를 입력해주세요 (선택)
+          </label>
+        </div>
         <input
           type="text"
           placeholder="EX) '하핑하핑'"

--- a/src/components/AdReportModal.jsx
+++ b/src/components/AdReportModal.jsx
@@ -70,13 +70,17 @@ const AdReportModal = ({
           )}
         </div>
         <div className="w-full">
-          <label className="block text-left text-sm whitespace-nowrap text-gray-600">
+          <label
+            htmlFor="adPhraseInput"
+            className="mb-2 block text-left text-sm text-gray-600"
+          >
             📌 광고로 판단되는 멘트를 입력해주세요 (선택)
           </label>
           <input
+            id="adPhraseInput"
             type="text"
             placeholder="EX) '하핑하핑'"
-            className="mt-2 mb-3 w-full rounded-lg border border-gray-300 px-4 py-2 focus:ring-2 focus:ring-blue-400 focus:outline-none"
+            className="mb-4 w-full rounded-lg border border-gray-300 px-4 py-2 focus:ring-2 focus:ring-blue-400 focus:outline-none"
           />
           <div className="flex justify-end gap-x-2">
             <Button

--- a/src/components/AdReportModal.jsx
+++ b/src/components/AdReportModal.jsx
@@ -53,8 +53,8 @@ const AdReportModal = ({
       title="현재 방송이 광고인지 선택해주세요."
       subTitle="광고일 경우, 채널을 변경할 수 있습니다."
     >
-      <div className="flex flex-col items-center">
-        <div className="w-[90%] max-w-[360px] text-left">
+      <div className="absolute inset-0 flex flex-col justify-between px-1">
+        <div className="max-h-[160px] overflow-hidden">
           {availableReportOptions.map(
             ([key, { parentOption, childrenOptions }]) => (
               <ToggleCheckbox
@@ -69,8 +69,6 @@ const AdReportModal = ({
             )
           )}
         </div>
-      </div>
-      <div className="absolute bottom-38">
         <div className="w-full">
           <label className="block text-left text-sm whitespace-nowrap text-gray-600">
             📌 광고로 판단되는 멘트를 입력해주세요 (선택)
@@ -78,24 +76,23 @@ const AdReportModal = ({
           <input
             type="text"
             placeholder="EX) '하핑하핑'"
-            className="mt-2 w-full rounded-lg border border-gray-300 px-4 py-2 transition focus:ring-2 focus:ring-blue-400 focus:outline-none"
+            className="mt-2 mb-3 w-full rounded-lg border border-gray-300 px-4 py-2 focus:ring-2 focus:ring-blue-400 focus:outline-none"
           />
-        </div>
-
-        <div className="mt-4 flex w-full justify-end gap-x-2">
-          <Button
-            className="flex h-[35px] w-[75px] items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-[16px] text-black hover:bg-gray-100"
-            onClick={onClose}
-          >
-            취소
-          </Button>
-          <Button
-            className="flex h-[35px] w-[75px] items-center justify-center rounded-md bg-[#5B4DFF] px-4 py-2 text-[16px] text-white hover:bg-[#4F46E5]"
-            onClick={handleSubmit}
-            disabled={!selectedParentOption || !selectedChildOption}
-          >
-            확인
-          </Button>
+          <div className="flex justify-end gap-x-2">
+            <Button
+              className="flex h-[35px] w-[75px] items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-[16px] text-black hover:bg-gray-100"
+              onClick={onClose}
+            >
+              취소
+            </Button>
+            <Button
+              className="flex h-[35px] w-[75px] items-center justify-center rounded-md bg-[#5B4DFF] px-4 py-2 text-[16px] text-white hover:bg-[#4F46E5]"
+              onClick={handleSubmit}
+              disabled={!selectedParentOption || !selectedChildOption}
+            >
+              확인
+            </Button>
+          </div>
         </div>
       </div>
     </Modal>

--- a/src/components/AdReportModal.jsx
+++ b/src/components/AdReportModal.jsx
@@ -70,6 +70,16 @@ const AdReportModal = ({
           )}
         </div>
       </div>
+      <form className="mt-5 w-full">
+        <label className="text-md block text-left text-gray-600">
+          📌광고라고 판단되는 멘트를 입력해주세요 (선택)
+        </label>
+        <input
+          type="text"
+          placeholder="EX) '하핑하핑'"
+          className="mt-2 w-full rounded-lg border border-gray-300 px-4 py-2 transition focus:ring-2 focus:ring-blue-400 focus:outline-none"
+        />
+      </form>
       <div className="mt-[25px] flex w-full justify-end gap-x-2">
         <Button
           className="flex h-[35px] w-[75px] items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-[16px] text-black hover:bg-gray-100"

--- a/src/components/ui/Modal.jsx
+++ b/src/components/ui/Modal.jsx
@@ -3,18 +3,15 @@ import WarningIcon from "@/assets/svgs/icon-warning-red.svg?react";
 const Modal = ({ title, subTitle, children }) => {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 px-4 backdrop-blur-sm">
-      <div className="flex min-h-[400px] w-full max-w-[360px] flex-col rounded-xl bg-white px-5 py-6 shadow-lg">
+      <div className="flex h-[420px] w-full max-w-[360px] flex-col rounded-xl bg-white px-5 py-6 shadow-lg">
         <div className="pb-2">
           <WarningIcon className="mx-auto h-11 w-11" />
         </div>
-
-        <div className="w-full text-center">
-          <div className="w-full text-center">
-            <p className="text-[18px] font-bold text-black">{title}</p>
-            <p className="mt-1 mb-3 text-[14px] text-gray-400">{subTitle}</p>
-          </div>
-          <div className="w-full">{children}</div>
+        <div className="text-center">
+          <p className="text-[18px] font-bold text-black">{title}</p>
+          <p className="mt-1 mb-3 text-[14px] text-gray-400">{subTitle}</p>
         </div>
+        <div className="relative flex-1">{children}</div>
       </div>
     </div>
   );

--- a/src/components/ui/Modal.jsx
+++ b/src/components/ui/Modal.jsx
@@ -3,7 +3,7 @@ import WarningIcon from "@/assets/svgs/icon-warning-red.svg?react";
 const Modal = ({ title, subTitle, children }) => {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 px-4 backdrop-blur-sm">
-      <div className="w-full max-w-[360px] rounded-xl bg-white px-5 py-6 shadow-lg sm:max-w-[420px]">
+      <div className="flex min-h-[400px] w-full max-w-[360px] flex-col rounded-xl bg-white px-5 py-6 shadow-lg">
         <div className="pb-2">
           <WarningIcon className="mx-auto h-11 w-11" />
         </div>


### PR DESCRIPTION
### ✨ 이슈 번호 

- #75 

### 📌 설명 

- 광고 멘트 입력을 위한 안내 문구 및 인풋 필드를 반응형으로 구현한 Pull Request입니다.  

### 📃 작업 사항 

- [x] 광고 멘트 안내 텍스트 UI 구현
- [x] 텍스트 한 줄 유지 및 반응형 대응 처리
- [x] 광고 멘트 입력창 UI 추가  
  - 안내 문구: `광고로 판단되는 멘트를 입력해주세요 (선택)`  
  - placeholder: `EX) 하핑하핑'`
  
### 💡 참고 사항 


https://github.com/user-attachments/assets/e75ad0f7-d6ec-48df-8da6-d1506e0c42cf

### 💭 리뷰 사항 반영 

- [x] 광고 제보 모달 UI CLS 제거 및 버튼 고정 처리
- [x] 광고 신고 모달 높이 조정으로 토글 영역 잘림 문제 해결
- [x] 광고 입력창에 htmlFor/id 추가하여 시멘틱 구조 개선
### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
