### PR TITLE
refactor: 광고 감지 여부에 따른 whisper 서버 연결

### DIFF
--- a/src/apis/radioChannels.js
+++ b/src/apis/radioChannels.js
@@ -1,4 +1,6 @@
 import axiosInstance from "@/apis/axiosInstance";
 
-export const getChannelInfo = (channelId) =>
-  axiosInstance.get(`/radio-channels/${channelId}`);
+export const getChannelInfo = (channelId, isAdDetect) =>
+  axiosInstance.get(`/radio-channels/${channelId}`, {
+    params: { isAdDetect },
+  });

--- a/src/components/MiniPlayer.jsx
+++ b/src/components/MiniPlayer.jsx
@@ -13,12 +13,13 @@ const MiniPlayer = ({ closePlayer }) => {
     useChannelStore();
   const { settings } = useUserStore();
   const isAdDetect = settings[SETTING_TYPES.AD_DETECT];
+
   const channel = radioChannelList.find(
     (channel) => channel.id === selectedChannelId
   );
-  const videoId = useRef(null);
-
   const { name, logoUrl } = channel;
+
+  const videoId = useRef(null);
 
   const handlePlayPause = () => {
     controlStreamingPlayback(videoId, selectedChannelId, isPlaying, isAdDetect);

--- a/src/components/MiniPlayer.jsx
+++ b/src/components/MiniPlayer.jsx
@@ -1,30 +1,12 @@
-import { useRef } from "react";
-
 import CloseIcon from "@/assets/svgs/icon-close.svg?react";
 import PauseIcon from "@/assets/svgs/icon-mini-pause.svg?react";
 import PlayIcon from "@/assets/svgs/icon-mini-player.svg?react";
-import { SETTING_TYPES } from "@/constants/settingOptions";
-import { useChannelStore } from "@/store/useChannelStore";
-import { useUserStore } from "@/store/useUserStore";
-import controlStreamingPlayback from "@/utils/playControl";
+import useChannelPlayback from "@/hooks/useChannelPlayback";
 
 const MiniPlayer = ({ closePlayer }) => {
-  const { selectedChannelId, radioChannelList, isPlaying, setIsPlaying } =
-    useChannelStore();
-  const { settings } = useUserStore();
-  const isAdDetect = settings[SETTING_TYPES.AD_DETECT];
-
-  const selectedChannel = radioChannelList.find(
-    ({ id }) => id === selectedChannelId
-  );
+  const { videoId, selectedChannel, isPlaying, handlePlayPause } =
+    useChannelPlayback();
   const { name, logoUrl } = selectedChannel;
-
-  const videoId = useRef(null);
-
-  const handlePlayPause = () => {
-    controlStreamingPlayback(videoId, selectedChannelId, isPlaying, isAdDetect);
-    setIsPlaying((prev) => !prev);
-  };
 
   return (
     <div className="flex h-20 w-full justify-between rounded-b-4xl bg-white px-4 shadow-[0_-6px_9px_rgba(0,0,0,0.3)]">

--- a/src/components/MiniPlayer.jsx
+++ b/src/components/MiniPlayer.jsx
@@ -14,10 +14,10 @@ const MiniPlayer = ({ closePlayer }) => {
   const { settings } = useUserStore();
   const isAdDetect = settings[SETTING_TYPES.AD_DETECT];
 
-  const channel = radioChannelList.find(
+  const selectedChannel = radioChannelList.find(
     (channel) => channel.id === selectedChannelId
   );
-  const { name, logoUrl } = channel;
+  const { name, logoUrl } = selectedChannel;
 
   const videoId = useRef(null);
 

--- a/src/components/MiniPlayer.jsx
+++ b/src/components/MiniPlayer.jsx
@@ -1,28 +1,35 @@
-import { useState, useRef } from "react";
+import { useRef } from "react";
 
 import CloseIcon from "@/assets/svgs/icon-close.svg?react";
 import PauseIcon from "@/assets/svgs/icon-mini-pause.svg?react";
 import PlayIcon from "@/assets/svgs/icon-mini-player.svg?react";
+import { SETTING_TYPES } from "@/constants/settingOptions";
+import { useChannelStore } from "@/store/useChannelStore";
+import { useUserStore } from "@/store/useUserStore";
 import controlStreamingPlayback from "@/utils/playControl";
 
-const MiniPlayer = ({ thumbnail, channelName, closePlayer }) => {
-  const [isPlaying, setIsPlaying] = useState(false);
+const MiniPlayer = ({ closePlayer }) => {
+  const { selectedChannelId, radioChannelList, isPlaying, setIsPlaying } =
+    useChannelStore();
+  const { settings } = useUserStore();
+  const isAdDetect = settings[SETTING_TYPES.AD_DETECT];
+  const channel = radioChannelList.find(
+    (channel) => channel.id === selectedChannelId
+  );
   const videoId = useRef(null);
 
+  const { name, logoUrl } = channel;
+
   const handlePlayPause = () => {
-    controlStreamingPlayback(videoId, !isPlaying);
+    controlStreamingPlayback(videoId, selectedChannelId, isPlaying, isAdDetect);
     setIsPlaying((prev) => !prev);
   };
 
   return (
     <div className="flex h-20 w-full justify-between rounded-b-4xl bg-white px-4 shadow-[0_-6px_9px_rgba(0,0,0,0.3)]">
       <div className="flex items-center">
-        <img
-          className="ml-2 h-16 w-16"
-          src={thumbnail}
-          alt={`${channelName} 썸네일`}
-        />
-        <p className="ml-2 text-sm font-black">{channelName}</p>
+        <img className="ml-2 h-16 w-16" src={logoUrl} alt={`${name} 썸네일`} />
+        <p className="ml-2 text-sm font-black">{name}</p>
       </div>
       <video ref={videoId} className="hidden" />
       <div className="flex items-center gap-3">

--- a/src/components/MiniPlayer.jsx
+++ b/src/components/MiniPlayer.jsx
@@ -15,7 +15,7 @@ const MiniPlayer = ({ closePlayer }) => {
   const isAdDetect = settings[SETTING_TYPES.AD_DETECT];
 
   const selectedChannel = radioChannelList.find(
-    (channel) => channel.id === selectedChannelId
+    ({ id }) => id === selectedChannelId
   );
   const { name, logoUrl } = selectedChannel;
 

--- a/src/hooks/useChannelPlayback.jsx
+++ b/src/hooks/useChannelPlayback.jsx
@@ -1,0 +1,33 @@
+import { useRef } from "react";
+
+import { SETTING_TYPES } from "@/constants/settingOptions";
+import { useChannelStore } from "@/store/useChannelStore";
+import { useUserStore } from "@/store/useUserStore";
+import controlStreamingPlayback from "@/utils/playControl";
+
+const useChannelPlayback = () => {
+  const { selectedChannelId, radioChannelList, isPlaying, setIsPlaying } =
+    useChannelStore();
+  const { settings } = useUserStore();
+  const isAdDetect = settings[SETTING_TYPES.AD_DETECT];
+
+  const selectedChannel = radioChannelList.find(
+    ({ id }) => id === selectedChannelId
+  );
+
+  const videoId = useRef(null);
+
+  const handlePlayPause = () => {
+    controlStreamingPlayback(videoId, selectedChannelId, isPlaying, isAdDetect);
+    setIsPlaying((prev) => !prev);
+  };
+
+  return {
+    videoId,
+    selectedChannel,
+    isPlaying,
+    handlePlayPause,
+  };
+};
+
+export default useChannelPlayback;

--- a/src/pages/ChannelPlayer.jsx
+++ b/src/pages/ChannelPlayer.jsx
@@ -15,10 +15,10 @@ const ChannelPlayer = ({ isChannelChanged }) => {
   const { settings } = useUserStore();
   const isAdDetect = settings[SETTING_TYPES.AD_DETECT];
 
-  const channel = radioChannelList.find(
+  const selectedChannel = radioChannelList.find(
     (channel) => channel.id === selectedChannelId
   );
-  const { name, logoUrl } = channel;
+  const { name, logoUrl } = selectedChannel;
 
   const videoId = useRef(null);
 

--- a/src/pages/ChannelPlayer.jsx
+++ b/src/pages/ChannelPlayer.jsx
@@ -16,7 +16,7 @@ const ChannelPlayer = ({ isChannelChanged }) => {
   const isAdDetect = settings[SETTING_TYPES.AD_DETECT];
 
   const selectedChannel = radioChannelList.find(
-    (channel) => channel.id === selectedChannelId
+    ({ id }) => id === selectedChannelId
   );
   const { name, logoUrl } = selectedChannel;
 

--- a/src/pages/ChannelPlayer.jsx
+++ b/src/pages/ChannelPlayer.jsx
@@ -6,13 +6,14 @@ import Button from "@/components/ui/Button";
 import ToggleButton from "@/components/ui/ToggleButton";
 import { SETTING_TYPES, SETTING_TITLES } from "@/constants/settingOptions";
 import { useChannelStore } from "@/store/useChannelStore";
+import { useUserStore } from "@/store/useUserStore";
 import controlStreamingPlayback from "@/utils/playControl";
 
 const ChannelPlayer = ({ isChannelChanged }) => {
-  const selectedChannelId = useChannelStore((state) => state.selectedChannelId);
-  const radioChannelList = useChannelStore((state) => state.radioChannelList);
-  const isPlaying = useChannelStore((state) => state.isPlaying);
-  const setIsPlaying = useChannelStore((state) => state.setIsPlaying);
+  const { selectedChannelId, radioChannelList, isPlaying, setIsPlaying } =
+    useChannelStore();
+  const { settings } = useUserStore();
+  const isAdDetect = settings[SETTING_TYPES.AD_DETECT];
   const channel = radioChannelList.find(
     (channel) => channel.id === selectedChannelId
   );
@@ -25,7 +26,7 @@ const ChannelPlayer = ({ isChannelChanged }) => {
     : SETTING_TITLES[SETTING_TYPES.AD_DETECT];
 
   const handlePlayPause = () => {
-    controlStreamingPlayback(videoId, selectedChannelId, isPlaying);
+    controlStreamingPlayback(videoId, selectedChannelId, isPlaying, isAdDetect);
     setIsPlaying((prev) => !prev);
   };
 

--- a/src/pages/ChannelPlayer.jsx
+++ b/src/pages/ChannelPlayer.jsx
@@ -14,12 +14,13 @@ const ChannelPlayer = ({ isChannelChanged }) => {
     useChannelStore();
   const { settings } = useUserStore();
   const isAdDetect = settings[SETTING_TYPES.AD_DETECT];
+
   const channel = radioChannelList.find(
     (channel) => channel.id === selectedChannelId
   );
-  const videoId = useRef(null);
-
   const { name, logoUrl } = channel;
+
+  const videoId = useRef(null);
 
   const buttonLabel = isChannelChanged
     ? SETTING_TITLES[SETTING_TYPES.RETURN_CHANNEL]

--- a/src/pages/ChannelPlayer.jsx
+++ b/src/pages/ChannelPlayer.jsx
@@ -1,35 +1,18 @@
-import { useRef } from "react";
-
 import MainPauseIcon from "@/assets/svgs/icon-main-pause.svg?react";
 import MainPlayIcon from "@/assets/svgs/icon-main-play.svg?react";
 import Button from "@/components/ui/Button";
 import ToggleButton from "@/components/ui/ToggleButton";
-import { SETTING_TYPES, SETTING_TITLES } from "@/constants/settingOptions";
-import { useChannelStore } from "@/store/useChannelStore";
-import { useUserStore } from "@/store/useUserStore";
-import controlStreamingPlayback from "@/utils/playControl";
+import { SETTING_TITLES, SETTING_TYPES } from "@/constants/settingOptions";
+import useChannelPlayback from "@/hooks/useChannelPlayback";
 
 const ChannelPlayer = ({ isChannelChanged }) => {
-  const { selectedChannelId, radioChannelList, isPlaying, setIsPlaying } =
-    useChannelStore();
-  const { settings } = useUserStore();
-  const isAdDetect = settings[SETTING_TYPES.AD_DETECT];
-
-  const selectedChannel = radioChannelList.find(
-    ({ id }) => id === selectedChannelId
-  );
+  const { videoId, selectedChannel, isPlaying, handlePlayPause } =
+    useChannelPlayback();
   const { name, logoUrl } = selectedChannel;
-
-  const videoId = useRef(null);
 
   const buttonLabel = isChannelChanged
     ? SETTING_TITLES[SETTING_TYPES.RETURN_CHANNEL]
     : SETTING_TITLES[SETTING_TYPES.AD_DETECT];
-
-  const handlePlayPause = () => {
-    controlStreamingPlayback(videoId, selectedChannelId, isPlaying, isAdDetect);
-    setIsPlaying((prev) => !prev);
-  };
 
   return (
     <div className="relative mx-auto flex h-[calc(100vh-80px)] max-w-md flex-col px-4 pb-28">

--- a/src/utils/playControl.js
+++ b/src/utils/playControl.js
@@ -7,13 +7,14 @@ let hlsInstance = null;
 const controlStreamingPlayback = async (
   videoRef,
   selectedChannelId,
-  isPlaying
+  isPlaying,
+  isAdDetect
 ) => {
   const video = videoRef.current;
 
   if (!isPlaying) {
     try {
-      const { data } = await getChannelInfo(selectedChannelId);
+      const { data } = await getChannelInfo(selectedChannelId, isAdDetect);
       const url = data.url;
 
       if (hlsInstance) {


### PR DESCRIPTION
### ✨ 이슈 번호

- #73 

### 📌 설명

- 광고 감지(isAdDetect) 여부에 따라 Whisper 서버로 요청을 보내는 로직을 추가를 구현한 Pull Request입니다.
- ChannelPlayer 컴포넌트에서 isAdDetect를 전달해주도록 변경했습니다.
- MiniPlayer 컴포넌트를 ChannelPlayer와 동일한 로직 흐름으로 변경했습니다.

### 📃 작업 사항

  - [x] getChannelInfo API에 광고 감지 여부(isAdDetect)를 query param으로 전달하도록 수정
  - [x] controlStreamingPlayback 함수에서 isAdDetect 여부에 따라 Whisper 서버 요청 여부 분기 처리
  - [x] ChannelPlayer controlStreamingPlayback 호출 시 isAdDetect 전달 로직 추가
    - [x] MiniPlayer 컴포넌트를 ChannelPlayer와 동일한 로직 흐름으로 변경

### 💡 참고 사항

- 백엔드와 함께 진행된 PR입니다.
- [백엔드 광고 감지 여부에 따른 whisper 서버 연결 PR](https://github.com/Radio-Premium/RadioPremium-BE/pull/53)

### 💭 리뷰 사항 반영 

- [x] 역할에 맞게 변수명 명확화
- [x] 구조 분해 할당을 사용 find 로직 간결화
- [x] useChannelPlayback로 ChannelPlayer, MiniPlayer 중복 로직 추출

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
