### PR TITLE
fix: 'settings' is not defined. 문제 해결

### DIFF
--- a/src/hooks/useChannelPlayback.jsx
+++ b/src/hooks/useChannelPlayback.jsx
@@ -26,7 +26,6 @@ const useChannelPlayback = () => {
     videoId,
     selectedChannel,
     isPlaying,
-    settings,
     handlePlayPause,
   };
 };

--- a/src/hooks/useChannelPlayback.jsx
+++ b/src/hooks/useChannelPlayback.jsx
@@ -26,6 +26,7 @@ const useChannelPlayback = () => {
     videoId,
     selectedChannel,
     isPlaying,
+    settings,
     handlePlayPause,
   };
 };

--- a/src/pages/ChannelPlayer.jsx
+++ b/src/pages/ChannelPlayer.jsx
@@ -7,10 +7,10 @@ import useChannelPlayback from "@/hooks/useChannelPlayback";
 import useUpdateSetting from "@/hooks/useUpdateSetting";
 
 const ChannelPlayer = ({ isChannelChanged }) => {
-  const { videoId, selectedChannel, isPlaying, handlePlayPause } =
+  const { videoId, selectedChannel, isPlaying, settings, handlePlayPause } =
     useChannelPlayback();
   const { name, logoUrl } = selectedChannel;
-  
+
   const buttonLabel = isChannelChanged
     ? SETTING_TITLES[SETTING_TYPES.RETURN_CHANNEL]
     : SETTING_TITLES[SETTING_TYPES.AD_DETECT];

--- a/src/pages/ChannelPlayer.jsx
+++ b/src/pages/ChannelPlayer.jsx
@@ -5,9 +5,10 @@ import ToggleButton from "@/components/ui/ToggleButton";
 import { SETTING_TITLES, SETTING_TYPES } from "@/constants/settingOptions";
 import useChannelPlayback from "@/hooks/useChannelPlayback";
 import useUpdateSetting from "@/hooks/useUpdateSetting";
+import { useUserStore } from "@/store/useUserStore";
 
 const ChannelPlayer = ({ isChannelChanged }) => {
-  const { videoId, selectedChannel, isPlaying, settings, handlePlayPause } =
+  const { videoId, selectedChannel, isPlaying, handlePlayPause } =
     useChannelPlayback();
   const { name, logoUrl } = selectedChannel;
 
@@ -18,6 +19,8 @@ const ChannelPlayer = ({ isChannelChanged }) => {
   const settingType = isChannelChanged
     ? SETTING_TYPES.RETURN_CHANNEL
     : SETTING_TYPES.AD_DETECT;
+
+  const { settings } = useUserStore();
 
   const updateSetting = useUpdateSetting(settingType);
 


### PR DESCRIPTION
### ✨ 이슈 번호

- #80 

### 📌 설명

현재 `ChannelPlayer`의 `settings`에서 `'settings' is not defined.` 에러가 발생하고 있습니다. 또한, `Home` 페이지에서 라디오 채널 목록에 라디오 채널을 클릭했을 때, `'settings' is not defined.` 에러가 발생하여 서비스를 정상적으로 사용할 수 없는 문제를 해결한 Pull Request입니다.

### 📃 작업 사항

- [x] 'settings' is not defined. 문제 해결 

### 💡 참고 사항

`useChannelPlayback`에서 `useUserStore`의 `settings` 정보를 다루고 있으므로 반환값에 `settings`를 추가해주고 `ChannelPlayer` 컴포넌트에서 해당 반환값을 가져오는 방식으로 해결했습니다.

### 💭 리뷰 사항 반영

- [x] `ChannelPlayer`처럼 실제로 `settings`를 사용하는 곳에서 `useUserStore`를 직접 호출하는 방식으로 변경

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
