### PR TITLE
feat: 광고 제보 모달에서 사용자 입력 받아 서버로 넘기는 로직 구현

### DIFF
--- a/src/components/AdReportModal.jsx
+++ b/src/components/AdReportModal.jsx
@@ -10,14 +10,10 @@ import {
 import useSubmitAdReport from "@/hooks/useSubmitAdReport";
 import useUserId from "@/hooks/useUserId";
 
-const AdReportModal = ({
-  isChannelChanged,
-  channelId,
-  detectedAdPhrase,
-  onClose,
-}) => {
+const AdReportModal = ({ isChannelChanged, channelId, onClose }) => {
   const [selectedParentOption, setSelectedParentOption] = useState(null);
   const [selectedChildOption, setSelectedChildOption] = useState(null);
+  const [userAdPhrase, setUserAdPhrase] = useState("");
 
   const submitAdReport = useSubmitAdReport();
   const userId = useUserId();
@@ -41,7 +37,7 @@ const AdReportModal = ({
     await submitAdReport({
       userId: Number(userId),
       isAd,
-      detectedAdPhrase,
+      detectedAdPhrase: userAdPhrase || null,
       channelId,
     });
 
@@ -80,6 +76,8 @@ const AdReportModal = ({
             id="adPhraseInput"
             type="text"
             placeholder="EX) '하핑하핑'"
+            value={userAdPhrase}
+            onChange={(e) => setUserAdPhrase(e.target.value)}
             className="mb-4 w-full rounded-lg border border-gray-300 px-4 py-2 focus:ring-2 focus:ring-blue-400 focus:outline-none"
           />
           <div className="flex justify-end gap-x-2">

--- a/src/components/AdReportModal.jsx
+++ b/src/components/AdReportModal.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 
 import ToggleCheckbox from "@/components/ToggleCheckbox";
 import Button from "@/components/ui/Button";
@@ -13,7 +13,7 @@ import useUserId from "@/hooks/useUserId";
 const AdReportModal = ({ isChannelChanged, channelId, onClose }) => {
   const [selectedParentOption, setSelectedParentOption] = useState(null);
   const [selectedChildOption, setSelectedChildOption] = useState(null);
-  const [userAdPhrase, setUserAdPhrase] = useState("");
+  const userAdPhrase = useRef("");
 
   const submitAdReport = useSubmitAdReport();
   const userId = useUserId();
@@ -37,7 +37,7 @@ const AdReportModal = ({ isChannelChanged, channelId, onClose }) => {
     await submitAdReport({
       userId: Number(userId),
       isAd,
-      detectedAdPhrase: userAdPhrase || null,
+      detectedAdPhrase: userAdPhrase.current || null,
       channelId,
     });
 
@@ -76,8 +76,8 @@ const AdReportModal = ({ isChannelChanged, channelId, onClose }) => {
             id="adPhraseInput"
             type="text"
             placeholder="EX) '하핑하핑'"
-            value={userAdPhrase}
-            onChange={(e) => setUserAdPhrase(e.target.value)}
+            defaultValue=""
+            onChange={(e) => (userAdPhrase.current = e.target.value)}
             className="mb-4 w-full rounded-lg border border-gray-300 px-4 py-2 focus:ring-2 focus:ring-blue-400 focus:outline-none"
           />
           <div className="flex justify-end gap-x-2">

--- a/src/components/header/ReportHeader.jsx
+++ b/src/components/header/ReportHeader.jsx
@@ -4,8 +4,11 @@ import { useNavigate } from "react-router-dom";
 import AdReportIcon from "@/assets/svgs/icon-ad-report.svg?react";
 import BackArrow from "@/assets/svgs/icon-back-arrow.svg?react";
 import AdReportModal from "@/components/AdReportModal";
+import { useChannelStore } from "@/store/useChannelStore";
 
 const ReportHeader = () => {
+  const channelId = useChannelStore((state) => state.selectedChannelId);
+
   const navigate = useNavigate();
   const [isAdReportModalOpen, setIsAdReportModalOpen] = useState(false);
 
@@ -26,7 +29,10 @@ const ReportHeader = () => {
         광고 제보하기
       </button>
       {isAdReportModalOpen && (
-        <AdReportModal onClose={() => setIsAdReportModalOpen(false)} />
+        <AdReportModal
+          onClose={() => setIsAdReportModalOpen(false)}
+          channelId={channelId}
+        />
       )}
     </div>
   );

--- a/src/components/header/index.jsx
+++ b/src/components/header/index.jsx
@@ -15,7 +15,7 @@ const Header = () => {
     return <RadioSearchInput />;
   }
 
-  if (/^\/channel\/\d+$/.test(pathname)) {
+  if (pathname === "/channel-player") {
     return <ReportHeader />;
   }
 


### PR DESCRIPTION
### ✨ 이슈 번호

- #79 

### 📌 설명 

- 채널 ID가 서버로 전달되지 않던 문제를 수정하고, 사용자 광고 멘트 입력값이 함께 저장되도록 연동한 Pull Request입니다.
- 사용자가 광고 멘트를 입력할 수 있도록 하고, 해당 멘트를 Supabase에 함께 저장되도록 연동했습니다.
- zustand에서 선택된 채널 ID를 가져와 AdReportModal에 전달하도록 연동했습니다.

### 📃 작업 사항

- [x] 광고 멘트 입력값 상태로 관리
- [x] 광고 멘트 입력값을 Supabase `user_reports` 테이블에 저장되도록 연동
- [x] 미입력 시 null 또는 빈 문자열 처리 로직 적용
- [x] zustand에서 `selectedChannelId`를 가져와 `AdReportModal`에 전달
- [x] 서버 전송 시 `channelId`포함되도록 수정
- [x] `ReportHeader`렌더링 조건을 "/channel-player"로 변경

### 💡 참고 사항 
**🔗광고 제보 요청 시 콘솔 출력 결과**

![image](https://github.com/user-attachments/assets/718119d1-1b26-4984-8570-ddfa13204c56)

**🔗Supabase user_reports 테이블 저장 확인**

![image](https://github.com/user-attachments/assets/fcc1faaf-9185-4664-b6e5-e916648a4b54)

### 💭 리뷰 사항 반영


### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
