### PR TITLE
feat: 광고 감지 시 광고 없는 채널로 전환하는 로직 구현

### DIFF
--- a/src/apis/radioChannels.js
+++ b/src/apis/radioChannels.js
@@ -4,3 +4,6 @@ export const getChannelInfo = (channelId, isAdDetect) =>
   axiosInstance.get(`/radio-channels/${channelId}`, {
     params: { isAdDetect },
   });
+
+export const getRandomNoAdChannel = () =>
+  axiosInstance.get("/radio-channels/random-no-ad");

--- a/src/hooks/useChannelSwitch.jsx
+++ b/src/hooks/useChannelSwitch.jsx
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 
+import { getRandomNoAdChannel } from "@/apis/radioChannels";
 import { useChannelStore } from "@/store/useChannelStore";
 
 const useChannelSwitch = () => {
@@ -11,9 +12,12 @@ const useChannelSwitch = () => {
       try {
         let channelId = 0;
         if (isAd) {
-          // TODO: 광고 없는 채널 id 랜덤으로 불러오기
-          channelId = 3;
-          setPrevChannelId(channelId);
+          try {
+            channelId = await getRandomNoAdChannel();
+            setPrevChannelId(channelId);
+          } catch (error) {
+            console.error("fetch randomNoAdchannel failed", error);
+          }
         } else {
           channelId = prevChannelId;
           setPrevChannelId(null);


### PR DESCRIPTION
### ✨ 이슈 번호

- #84 

### 📌 설명

- 광고가 감지되었을 때 기존 하드코딩된 채널 ID가 아닌 광고 없는 채널을 백엔드에서 랜덤으로 받아오도록 광고 없는 라디오 채널 조회 API를 연동을 구현하여 작성한 Pull Request입니다.

### 📃 작업 사항

- [x] 광고 없는 라디오 채널 조회 API를 연동
- [x] /radio-channels/random-no-ad API 호출 로직 추가

### 💭 리뷰 사항 반영

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
