### PR TITLE
feat: 광고 감지 기반 스트리밍 소스 교체 기능 추가 및 관련 로직 리팩토링

### DIFF
--- a/src/hooks/useAdKeywordsSocketListener.jsx
+++ b/src/hooks/useAdKeywordsSocketListener.jsx
@@ -3,8 +3,8 @@ import { useEffect } from "react";
 import useChannelSwitch from "@/hooks/useChannelSwitch";
 import socket from "@/sockets/socketClient";
 
-const useAdKeywordsSocketListener = () => {
-  const handleChannelSwitch = useChannelSwitch();
+const useAdKeywordsSocketListener = (videoId) => {
+  const handleChannelSwitch = useChannelSwitch(videoId);
 
   useEffect(() => {
     socket.on("connect", () => {

--- a/src/hooks/useChannelPlayback.jsx
+++ b/src/hooks/useChannelPlayback.jsx
@@ -3,7 +3,7 @@ import { useRef } from "react";
 import { SETTING_TYPES } from "@/constants/settingOptions";
 import { useChannelStore } from "@/store/useChannelStore";
 import { useUserStore } from "@/store/useUserStore";
-import controlStreamingPlayback from "@/utils/playControl";
+import { controlStreamingPlayback } from "@/utils/playControl";
 
 const useChannelPlayback = () => {
   const { selectedChannelId, radioChannelList, isPlaying, setIsPlaying } =

--- a/src/hooks/useChannelSwitch.jsx
+++ b/src/hooks/useChannelSwitch.jsx
@@ -1,11 +1,16 @@
 import { useCallback } from "react";
 
 import { getRandomNoAdChannel } from "@/apis/radioChannels";
+import { SETTING_TYPES } from "@/constants/settingOptions";
 import { useChannelStore } from "@/store/useChannelStore";
+import { useUserStore } from "@/store/useUserStore";
+import { controlStreamingSwitch } from "@/utils/playControl";
 
-const useChannelSwitch = () => {
+const useChannelSwitch = (videoRef) => {
   const prevChannelId = useChannelStore((state) => state.prevChannelId);
   const setPrevChannelId = useChannelStore((state) => state.setPrevChannelId);
+  const { settings } = useUserStore();
+  const isAdDetect = settings[SETTING_TYPES.AD_DETECT];
 
   const handleChannelSwitch = useCallback(
     async (isAd) => {
@@ -22,13 +27,13 @@ const useChannelSwitch = () => {
           channelId = prevChannelId;
           setPrevChannelId(null);
         }
-        // TODO: 멈춤없이 라디오 음성을 연속 재생하려면 네비게이팅이 아닌 video의 src 속성을 변경해야 함
-        // navigate(`/channel/${channelId}`);
+
+        await controlStreamingSwitch(videoRef, channelId, isAdDetect);
       } catch (error) {
         console.error("switch failed: ", error);
       }
     },
-    [prevChannelId, setPrevChannelId]
+    [prevChannelId, setPrevChannelId, isAdDetect, videoRef]
   );
 
   return handleChannelSwitch;

--- a/src/hooks/useChannelSwitch.jsx
+++ b/src/hooks/useChannelSwitch.jsx
@@ -24,6 +24,10 @@ const useChannelSwitch = (videoRef) => {
             console.error("fetch randomNoAdchannel failed", error);
           }
         } else {
+          if (prevChannelId == null) {
+            return;
+          }
+
           channelId = prevChannelId;
           setPrevChannelId(null);
         }

--- a/src/hooks/useChannelSwitch.jsx
+++ b/src/hooks/useChannelSwitch.jsx
@@ -18,7 +18,8 @@ const useChannelSwitch = (videoRef) => {
         let channelId = 0;
         if (isAd) {
           try {
-            channelId = await getRandomNoAdChannel();
+            const { data } = await getRandomNoAdChannel();
+            channelId = data.id;
             setPrevChannelId(channelId);
           } catch (error) {
             console.error("fetch randomNoAdchannel failed", error);

--- a/src/hooks/useChannelSwitch.jsx
+++ b/src/hooks/useChannelSwitch.jsx
@@ -25,7 +25,7 @@ const useChannelSwitch = (videoRef) => {
             console.error("fetch randomNoAdchannel failed", error);
           }
         } else {
-          if (prevChannelId == null) {
+          if (prevChannelId === null || prevChannelId === undefined) {
             return;
           }
 

--- a/src/pages/ChannelPlayer.jsx
+++ b/src/pages/ChannelPlayer.jsx
@@ -3,6 +3,7 @@ import MainPlayIcon from "@/assets/svgs/icon-main-play.svg?react";
 import Button from "@/components/ui/Button";
 import ToggleButton from "@/components/ui/ToggleButton";
 import { SETTING_TITLES, SETTING_TYPES } from "@/constants/settingOptions";
+import useAdKeywordsSocketListener from "@/hooks/useAdKeywordsSocketListener";
 import useChannelPlayback from "@/hooks/useChannelPlayback";
 import useUpdateSetting from "@/hooks/useUpdateSetting";
 import { useUserStore } from "@/store/useUserStore";
@@ -11,6 +12,8 @@ const ChannelPlayer = ({ isChannelChanged }) => {
   const { videoId, selectedChannel, isPlaying, handlePlayPause } =
     useChannelPlayback();
   const { name, logoUrl } = selectedChannel;
+
+  useAdKeywordsSocketListener(videoId);
 
   const buttonLabel = isChannelChanged
     ? SETTING_TITLES[SETTING_TYPES.RETURN_CHANNEL]


### PR DESCRIPTION
### ✨ 이슈 번호

- #86

### 📌 설명

- 광고 감지 시 video의 src를 교체하여 광고 없는 채널로 전환할 수 있도록 구현하여 작성한 Pull Request입니다.

### 📃 작업 사항

- [x] useChannelSwitch 훅에 video의 src를 교체 기능 추가
  - [x] 스트리밍 소스 교체 함수 호출
  - [x] videoRef 주입 방식 도입
- [x] 스트리밍 소스 교체 함수 controlStreamingSwitch
  - [x] controlStreamingPlayback, controlStreamingSwitch 역할 분리
  - [x] startStreamingPlay 공통 함수 추출
- [x] ChannelPlayer에서 광고 감지 소켓 연결
  - [x] videoRef 연동

### 💭 리뷰 사항 반영

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
