### PR TITLE
fix: 관심 채널 즐겨찾기 등록 및 정렬 동작 개선

### DIFF
--- a/src/hooks/useCategorizeChannels.jsx
+++ b/src/hooks/useCategorizeChannels.jsx
@@ -15,8 +15,8 @@ const useCategorizeChannels = () => {
       return;
     }
 
-    const favoriteList = interestChannelIds.map((id) =>
-      radioChannelList.find((channelInfo) => channelInfo.id === id)
+    const favoriteList = interestChannelIds.map((interestId) =>
+      radioChannelList.find((channelInfo) => channelInfo.id === interestId)
     );
     setFavoriteChannelList(favoriteList);
 

--- a/src/hooks/useCategorizeChannels.jsx
+++ b/src/hooks/useCategorizeChannels.jsx
@@ -15,8 +15,8 @@ const useCategorizeChannels = () => {
       return;
     }
 
-    const favoriteList = radioChannelList.filter((channelInfo) =>
-      interestChannelIds.includes(channelInfo.id)
+    const favoriteList = interestChannelIds.map((id) =>
+      radioChannelList.find((channelInfo) => channelInfo.id === id)
     );
     setFavoriteChannelList(favoriteList);
 

--- a/src/hooks/useToggleFavorite.jsx
+++ b/src/hooks/useToggleFavorite.jsx
@@ -7,10 +7,10 @@ import { useChannelStore } from "@/store/useChannelStore";
 
 const useToggleFavorite = () => {
   const { interestChannelIds, setInterestChannelIds } = useChannelStore();
-  const userId = useUserId();
+  const userId = Number(useUserId());
 
   const toggleFavorite = async (channelId) => {
-    if (!userId || !channelId) {
+    if (typeof userId !== "number" || typeof channelId !== "number") {
       return;
     }
 


### PR DESCRIPTION
### ✨ 이슈 번호

- #89 

### 📌 설명

- 특정 채널(channelId 0번) 즐겨찾기 불가 문제를 해결합니다.
- 관심 채널 리스트 정렬이 우선순위대로 동작하지 않는 문제 해결합니다.

### 📃 작업 사항

- [x] 특정 채널(channelId 0번) 즐겨찾기 불가 문제를 해결
  - [x] 0번 userId/channelId가 무시되지 않도록 early return 조건문 수정
- [x] 관심 채널 리스트 정렬이 우선순위대로 동작하지 않는 문제 수정
  - [x] 관심 채널 ID 배열을 기반으로 채널 정보 리스트 생성

### 💭 리뷰 사항 반영

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
