### PR TITLE
feat: MiniPlayer 연동

### DIFF
--- a/src/components/MiniPlayer.jsx
+++ b/src/components/MiniPlayer.jsx
@@ -2,11 +2,24 @@ import CloseIcon from "@/assets/svgs/icon-close.svg?react";
 import PauseIcon from "@/assets/svgs/icon-mini-pause.svg?react";
 import PlayIcon from "@/assets/svgs/icon-mini-play.svg?react";
 import useChannelPlayback from "@/hooks/useChannelPlayback";
+import { useMiniPlayerStore } from "@/store/useMiniPlayerStore";
+import { usePlayingStore } from "@/store/usePlayingStore";
+import { getGlobalVideo } from "@/utils/videoElement";
 
-const MiniPlayer = ({ closePlayer }) => {
+const MiniPlayer = () => {
   const { videoId, selectedChannel, isPlaying, handlePlayPause } =
-    useChannelPlayback();
+    useChannelPlayback("mini");
+  const { closeMiniPlayer } = useMiniPlayerStore();
+  const { setIsPlaying } = usePlayingStore();
   const { name, logoUrl } = selectedChannel;
+
+  const handleClose = () => {
+    const video = getGlobalVideo();
+    video.pause();
+    video.src = "";
+    setIsPlaying(false);
+    closeMiniPlayer();
+  };
 
   return (
     <div className="absolute bottom-0 flex h-20 w-full justify-between rounded-t-4xl bg-white px-4 shadow-[0_-6px_9px_rgba(0,0,0,0.3)]">
@@ -24,7 +37,7 @@ const MiniPlayer = ({ closePlayer }) => {
         ) : (
           <PauseIcon className="cursor-pointer" onClick={handlePlayPause} />
         )}
-        <CloseIcon className="cursor-pointer" onClick={closePlayer} />
+        <CloseIcon className="cursor-pointer" onClick={handleClose} />
       </div>
     </div>
   );

--- a/src/components/MiniPlayer.jsx
+++ b/src/components/MiniPlayer.jsx
@@ -7,7 +7,7 @@ import { usePlayingStore } from "@/store/usePlayingStore";
 import { getGlobalVideo } from "@/utils/videoElement";
 
 const MiniPlayer = () => {
-  const { videoId, selectedChannel, isPlaying, handlePlayPause } =
+  const { selectedChannel, isPlaying, handlePlayPause } =
     useChannelPlayback("mini");
   const { closeMiniPlayer } = useMiniPlayerStore();
   const { setIsPlaying } = usePlayingStore();
@@ -27,7 +27,6 @@ const MiniPlayer = () => {
         <img className="ml-2 h-16 w-16" src={logoUrl} alt={`${name} 썸네일`} />
         <p className="ml-2 text-sm font-black">{name}</p>
       </div>
-      <video ref={videoId} className="hidden" />
       <div className="flex items-center gap-3">
         {!isPlaying ? (
           <PlayIcon

--- a/src/components/MiniPlayer.jsx
+++ b/src/components/MiniPlayer.jsx
@@ -9,7 +9,7 @@ const MiniPlayer = ({ closePlayer }) => {
   const { name, logoUrl } = selectedChannel;
 
   return (
-    <div className="flex h-20 w-full justify-between rounded-b-4xl bg-white px-4 shadow-[0_-6px_9px_rgba(0,0,0,0.3)]">
+    <div className="absolute bottom-0 flex h-20 w-full justify-between rounded-t-4xl bg-white px-4 shadow-[0_-6px_9px_rgba(0,0,0,0.3)]">
       <div className="flex items-center">
         <img className="ml-2 h-16 w-16" src={logoUrl} alt={`${name} 썸네일`} />
         <p className="ml-2 text-sm font-black">{name}</p>

--- a/src/components/MiniPlayer.jsx
+++ b/src/components/MiniPlayer.jsx
@@ -1,6 +1,6 @@
 import CloseIcon from "@/assets/svgs/icon-close.svg?react";
 import PauseIcon from "@/assets/svgs/icon-mini-pause.svg?react";
-import PlayIcon from "@/assets/svgs/icon-mini-player.svg?react";
+import PlayIcon from "@/assets/svgs/icon-mini-play.svg?react";
 import useChannelPlayback from "@/hooks/useChannelPlayback";
 
 const MiniPlayer = ({ closePlayer }) => {

--- a/src/hooks/useChannelPlayback.jsx
+++ b/src/hooks/useChannelPlayback.jsx
@@ -1,32 +1,46 @@
-import { useRef } from "react";
-
 import { SETTING_TYPES } from "@/constants/settingOptions";
 import { useChannelStore } from "@/store/useChannelStore";
+import { useMiniPlayerStore } from "@/store/useMiniPlayerStore";
+import { usePlayingStore } from "@/store/usePlayingStore";
 import { useUserStore } from "@/store/useUserStore";
 import { controlStreamingPlayback } from "@/utils/playControl";
+import { getGlobalVideo } from "@/utils/videoElement";
 
-const useChannelPlayback = () => {
-  const { selectedChannelId, radioChannelList, isPlaying, setIsPlaying } =
-    useChannelStore();
+const useChannelPlayback = (mode) => {
+  const { selectedChannelId, radioChannelList } = useChannelStore();
+  const { playingChannelId, openMiniPlayer } = useMiniPlayerStore();
+  const { isPlaying, setIsPlaying } = usePlayingStore();
   const { settings } = useUserStore();
+  const video = getGlobalVideo();
   const isAdDetect = settings[SETTING_TYPES.AD_DETECT];
 
+  const isMiniMode = mode === "mini";
+  const targetChannelId = isMiniMode ? playingChannelId : selectedChannelId;
+
   const selectedChannel = radioChannelList.find(
-    ({ id }) => id === selectedChannelId
+    ({ id }) => id === targetChannelId
   );
 
-  const videoId = useRef(null);
+  const isCurrentPlaying = isMiniMode
+    ? isPlaying && playingChannelId !== null
+    : isPlaying && selectedChannelId === playingChannelId;
 
   const handlePlayPause = () => {
-    controlStreamingPlayback(videoId, selectedChannelId, isPlaying, isAdDetect);
-    setIsPlaying((prev) => !prev);
+    if (!isCurrentPlaying) {
+      controlStreamingPlayback(video, targetChannelId, false, isAdDetect);
+      openMiniPlayer(targetChannelId);
+      setIsPlaying(true);
+    } else {
+      controlStreamingPlayback(video, targetChannelId, true, isAdDetect);
+      setIsPlaying(false);
+    }
   };
 
   return {
-    videoId,
     selectedChannel,
-    isPlaying,
+    isPlaying: isCurrentPlaying,
     handlePlayPause,
+    videoId: video,
   };
 };
 

--- a/src/hooks/useChannelPlayback.jsx
+++ b/src/hooks/useChannelPlayback.jsx
@@ -37,10 +37,10 @@ const useChannelPlayback = (mode) => {
   };
 
   return {
+    videoId: video,
     selectedChannel,
     isPlaying: isCurrentPlaying,
     handlePlayPause,
-    videoId: video,
   };
 };
 

--- a/src/layout/MainLayout.jsx
+++ b/src/layout/MainLayout.jsx
@@ -1,8 +1,12 @@
 import { Outlet } from "react-router-dom";
 
 import Header from "@/components/header";
+import MiniPlayer from "@/components/MiniPlayer";
+import { useMiniPlayerStore } from "@/store/useMiniPlayerStore";
 
 const MainLayout = () => {
+  const isVisible = useMiniPlayerStore((state) => state.isVisible);
+
   return (
     <div className="flex justify-center bg-purple-50">
       <div className="relative min-h-dvh w-full max-w-[480px] bg-white shadow-lg">
@@ -10,6 +14,14 @@ const MainLayout = () => {
         <main>
           <Outlet />
         </main>
+        <video
+          id="global-radio"
+          className="hidden"
+          playsInline
+          autoPlay
+          controls={false}
+        />
+        {isVisible && <MiniPlayer />}
       </div>
     </div>
   );

--- a/src/pages/ChannelPlayer.jsx
+++ b/src/pages/ChannelPlayer.jsx
@@ -50,7 +50,6 @@ const ChannelPlayer = ({ isChannelChanged }) => {
             onToggle={handleToggle}
           />
         </div>
-        <video ref={videoId} className="hidden" />
         <Button className="mt-12" onClick={handlePlayPause}>
           {isPlaying ? (
             <MainPauseIcon className="h-[60px] w-[60px] sm:h-[75px] sm:w-[75px]" />

--- a/src/pages/ChannelPlayer.jsx
+++ b/src/pages/ChannelPlayer.jsx
@@ -10,7 +10,7 @@ import { useUserStore } from "@/store/useUserStore";
 
 const ChannelPlayer = ({ isChannelChanged }) => {
   const { videoId, selectedChannel, isPlaying, handlePlayPause } =
-    useChannelPlayback();
+    useChannelPlayback("full");
   const { name, logoUrl } = selectedChannel;
 
   useAdKeywordsSocketListener(videoId);

--- a/src/store/useChannelStore.js
+++ b/src/store/useChannelStore.js
@@ -2,22 +2,23 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
 export const useChannelStore = create(
-  persist((set) => ({
-    interestChannelIds: [],
-    prevChannelId: null,
-    radioChannelList: [],
-    selectedChannelId: null,
-    isPlaying: false,
+  persist(
+    (set) => ({
+      interestChannelIds: [],
+      prevChannelId: null,
+      radioChannelList: [],
+      selectedChannelId: null,
 
-    setInterestChannelIds: (interestChannelIds) =>
-      set({ interestChannelIds: interestChannelIds }),
-    setPrevChannelId: (channelId) => set({ prevChannelId: channelId }),
-    setRadioChannelList: (channelList) =>
-      set({ radioChannelList: channelList }),
-    setSelectedChannelId: (channelId) => set({ selectedChannelId: channelId }),
-    setIsPlaying: (updater) =>
-      typeof updater === "function"
-        ? set((state) => ({ isPlaying: updater(state.isPlaying) }))
-        : set({ isPlaying: updater }),
-  }))
+      setInterestChannelIds: (interestChannelIds) =>
+        set({ interestChannelIds }),
+      setPrevChannelId: (channelId) => set({ prevChannelId: channelId }),
+      setRadioChannelList: (channelList) =>
+        set({ radioChannelList: channelList }),
+      setSelectedChannelId: (channelId) =>
+        set({ selectedChannelId: channelId }),
+    }),
+    {
+      name: "channel-storage",
+    }
+  )
 );

--- a/src/store/useMiniPlayerStore.js
+++ b/src/store/useMiniPlayerStore.js
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+export const useMiniPlayerStore = create((set) => ({
+  isVisible: false,
+  playingChannelId: null,
+
+  openMiniPlayer: (channelId) =>
+    set({ isVisible: true, playingChannelId: channelId }),
+
+  closeMiniPlayer: () => set({ isVisible: false, playingChannelId: null }),
+}));

--- a/src/store/usePlayingStore.js
+++ b/src/store/usePlayingStore.js
@@ -1,0 +1,10 @@
+import { create } from "zustand";
+
+export const usePlayingStore = create((set) => ({
+  isPlaying: false,
+
+  setIsPlaying: (updater) =>
+    typeof updater === "function"
+      ? set((state) => ({ isPlaying: updater(state.isPlaying) }))
+      : set({ isPlaying: updater }),
+}));

--- a/src/utils/playControl.js
+++ b/src/utils/playControl.js
@@ -24,12 +24,11 @@ export const startStreamingPlay = (video, url) => {
 };
 
 export const controlStreamingPlayback = async (
-  videoRef,
+  video,
   channelId,
   isPlaying,
   isAdDetect
 ) => {
-  const video = videoRef.current;
   if (!isPlaying) {
     try {
       const { data } = await getChannelInfo(channelId, isAdDetect);
@@ -42,12 +41,7 @@ export const controlStreamingPlayback = async (
   }
 };
 
-export const controlStreamingSwitch = async (
-  videoRef,
-  channelId,
-  isAdDetect
-) => {
-  const video = videoRef.current;
+export const controlStreamingSwitch = async (video, channelId, isAdDetect) => {
   try {
     const { data } = await getChannelInfo(channelId, isAdDetect);
     startStreamingPlay(video, data.url);

--- a/src/utils/videoElement.js
+++ b/src/utils/videoElement.js
@@ -1,0 +1,1 @@
+export const getGlobalVideo = () => document.getElementById("global-radio");


### PR DESCRIPTION
### ✨ 이슈 번호

- #91 

### 📌 설명

라디오 채널에서 재생 버튼을 누르면 MiniPlayer가 나타나도록 연동 작업을 진행한 Pull Request입니다.

### 📃 작업 사항

- [x] MiniPlayer 연동

### 💡 참고 사항

* 이번 PR에서는 MiniPlayer와 ChannelPlayer가 동일한 전역 오디오 자원(video) 를 공유하도록 구조를 통합했습니다.
* useChannelPlayback 훅에 "mini" | "full" 모드를 도입하여, 재생 컨텍스트를 명확히 분리했습니다.
* "full": ChannelPlayer에서 현재 선택된 채널 기준으로 재생 상태를 판단합니다.
* "mini": playingChannelId 기준으로 미니플레이어 재생 상태를 판단합니다.
* A 채널에서 재생 중인 상태로 B 채널 상세로 이동해도, MiniPlayer에는 A 채널 정보 및 재생 상태가 유지됩니다.
* 이때 B 채널에서 재생 버튼을 누르면, MiniPlayer는 B 채널로 업데이트되며 A → B로 재생이 전환됩니다.
* videoRef 대신 전역 video 요소를 사용하도록 변경되었기 때문에, 미니플레이어를 종료할 때 video.pause() 및 video.src = "" 처리로 
명시적 정리 로직을 추가했습니다.

### 💭 리뷰 사항 반영

- [x] `MiniPlayer`와 `ChannelPlayer` 컴포넌트에 `<video>` 태그 제거

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
