### PR TITLE
refactor: 소켓 이벤트 핸들러 분리 및 userId null 체크 추가

### DIFF
--- a/src/hooks/useAdKeywordsSocketListener.jsx
+++ b/src/hooks/useAdKeywordsSocketListener.jsx
@@ -9,7 +9,9 @@ const useAdKeywordsSocketListener = (videoId) => {
   const userId = useUserId();
 
   useEffect(() => {
-    if (!userId) return;
+    if (!userId) {
+      return;
+    }
 
     const handleConnect = () => {
       console.log("connected");

--- a/src/hooks/useAdKeywordsSocketListener.jsx
+++ b/src/hooks/useAdKeywordsSocketListener.jsx
@@ -9,23 +9,33 @@ const useAdKeywordsSocketListener = (videoId) => {
   const userId = useUserId();
 
   useEffect(() => {
-    socket.on("connect", () => {
+    if (!userId) return;
+
+    const handleConnect = () => {
       console.log("connected");
       socket.emit("registerUser", { userId });
-    });
+    };
 
-    socket.on("radioText", ({ isAd }) => {
+    const handleRadioText = ({ isAd }) => {
       handleChannelSwitch(isAd);
-    });
+    };
 
-    socket.on("disconnect", () => {
-      console.log("disconnect");
-    });
+    const handleDisconnect = () => {
+      console.log("disconnected");
+    };
+
+    socket.on("connect", handleConnect);
+    socket.on("radioText", handleRadioText);
+    socket.on("disconnect", handleDisconnect);
+
+    if (socket.connected) {
+      handleConnect();
+    }
 
     return () => {
-      socket.off("connect");
-      socket.off("radioText");
-      socket.off("disconnect");
+      socket.off("connect", handleConnect);
+      socket.off("radioText", handleRadioText);
+      socket.off("disconnect", handleDisconnect);
     };
   }, [handleChannelSwitch, userId]);
 };


### PR DESCRIPTION
### ✨ 이슈 번호

- #95 

### 📌 설명

- `useAdKeywordsSocketListener`에서 소켓 이벤트 핸들러를 함수로 분리를 구현하여 작성한 Pull Request입니다.
  - `socket.off`도 안전하게 등록된 핸들러 기준으로 해제할 수 있습니다.
  - 소켓이 이미 연결된 상태일 경우 `handleConnect` 수동 호출하여 이벤트 누락을 방지합니다.
- `userId`가 존재하지 않을 경우 조기 `return`하도록 처리하여 불필요한 `socket.emit` 호출을 방지합니다.

### 📃 작업 사항

- [x] 소켓 이벤트 핸들러 함수로 분리 (`handleConnect`, `handleRadioText`, `handleDisconnect`)
- [x] 소켓이 이미 연결된 상태일 경우 `handleConnect` 수동 호출
- [x] `socket.off` 시 등록된 핸들러를 함께 제거하도록 변경
- [x] `userId`가 없을 경우 조기 `return` 처리

### 💭 리뷰 사항 반영

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
