### PR TITLE
feat: 광고 감지 시 플레이어 채널 정보 변경

### DIFF
--- a/src/hooks/useChannelSwitch.jsx
+++ b/src/hooks/useChannelSwitch.jsx
@@ -2,13 +2,14 @@ import { useCallback } from "react";
 
 import { getRandomNoAdChannel } from "@/apis/radioChannels";
 import { SETTING_TYPES } from "@/constants/settingOptions";
+import useControlStreamingSwitch from "@/hooks/useControlStreamingSwitch";
 import { useChannelStore } from "@/store/useChannelStore";
 import { useUserStore } from "@/store/useUserStore";
-import { controlStreamingSwitch } from "@/utils/playControl";
 
 const useChannelSwitch = (videoRef) => {
   const prevChannelId = useChannelStore((state) => state.prevChannelId);
   const setPrevChannelId = useChannelStore((state) => state.setPrevChannelId);
+  const controlStreamingSwitch = useControlStreamingSwitch();
   const { settings } = useUserStore();
   const isAdDetect = settings[SETTING_TYPES.AD_DETECT];
 
@@ -38,7 +39,13 @@ const useChannelSwitch = (videoRef) => {
         console.error("switch failed: ", error);
       }
     },
-    [prevChannelId, setPrevChannelId, isAdDetect, videoRef]
+    [
+      prevChannelId,
+      setPrevChannelId,
+      isAdDetect,
+      videoRef,
+      controlStreamingSwitch,
+    ]
   );
 
   return handleChannelSwitch;

--- a/src/hooks/useControlStreamingSwitch.jsx
+++ b/src/hooks/useControlStreamingSwitch.jsx
@@ -9,13 +9,17 @@ const useControlStreamingSwitch = () => {
   const { setSelectedChannelId, setIsChannelChanged } = useChannelStore();
   const { setPlayingChannelId } = useMiniPlayerStore();
 
+  const updateChannelState = (channelId) => {
+    setSelectedChannelId(channelId);
+    setPlayingChannelId(channelId);
+    setIsChannelChanged(true);
+  };
+
   const controlStreamingSwitch = async (video, channelId, isAdDetect) => {
     try {
       const { data } = await getChannelInfo(channelId, isAdDetect, userId);
       startStreamingPlay(video, data.url);
-      setSelectedChannelId(channelId);
-      setPlayingChannelId(channelId);
-      setIsChannelChanged(true);
+      updateChannelState(channelId);
     } catch (error) {
       console.error("fetch channelInfo failed", error);
     }

--- a/src/hooks/useControlStreamingSwitch.jsx
+++ b/src/hooks/useControlStreamingSwitch.jsx
@@ -3,8 +3,6 @@ import { useChannelStore } from "@/store/useChannelStore";
 import { useMiniPlayerStore } from "@/store/useMiniPlayerStore";
 import { startStreamingPlay } from "@/utils/playControl";
 
-const userId = localStorage.getItem("userId");
-
 const useControlStreamingSwitch = () => {
   const { setSelectedChannelId, setIsChannelChanged } = useChannelStore();
   const { setPlayingChannelId } = useMiniPlayerStore();
@@ -16,6 +14,7 @@ const useControlStreamingSwitch = () => {
   };
 
   const controlStreamingSwitch = async (video, channelId, isAdDetect) => {
+    const userId = localStorage.getItem("userId");
     try {
       const { data } = await getChannelInfo(channelId, isAdDetect, userId);
       startStreamingPlay(video, data.url);

--- a/src/hooks/useControlStreamingSwitch.jsx
+++ b/src/hooks/useControlStreamingSwitch.jsx
@@ -1,0 +1,27 @@
+import { getChannelInfo } from "@/apis/radioChannels";
+import { useChannelStore } from "@/store/useChannelStore";
+import { useMiniPlayerStore } from "@/store/useMiniPlayerStore";
+import { startStreamingPlay } from "@/utils/playControl";
+
+const userId = localStorage.getItem("userId");
+
+const useControlStreamingSwitch = () => {
+  const { setSelectedChannelId, setIsChannelChanged } = useChannelStore();
+  const { setPlayingChannelId } = useMiniPlayerStore();
+
+  const controlStreamingSwitch = async (video, channelId, isAdDetect) => {
+    try {
+      const { data } = await getChannelInfo(channelId, isAdDetect, userId);
+      startStreamingPlay(video, data.url);
+      setSelectedChannelId(channelId);
+      setPlayingChannelId(channelId);
+      setIsChannelChanged(true);
+    } catch (error) {
+      console.error("fetch channelInfo failed", error);
+    }
+  };
+
+  return controlStreamingSwitch;
+};
+
+export default useControlStreamingSwitch;

--- a/src/pages/ChannelPlayer.jsx
+++ b/src/pages/ChannelPlayer.jsx
@@ -12,21 +12,17 @@ import { useUserStore } from "@/store/useUserStore";
 const ChannelPlayer = () => {
   const { videoId, selectedChannel, isPlaying, handlePlayPause } =
     useChannelPlayback("full");
-  const { name, logoUrl } = selectedChannel;
-
+  const isChannelChanged = useChannelStore((state) => state.isChannelChanged);
+  const { settings } = useUserStore();
   useAdKeywordsSocketListener(videoId);
 
-  const isChannelChanged = useChannelStore((state) => state.isChannelChanged);
-  const buttonLabel = isChannelChanged
-    ? SETTING_TITLES[SETTING_TYPES.RETURN_CHANNEL]
-    : SETTING_TITLES[SETTING_TYPES.AD_DETECT];
+  const { name, logoUrl } = selectedChannel;
 
   const settingType = isChannelChanged
     ? SETTING_TYPES.RETURN_CHANNEL
     : SETTING_TYPES.AD_DETECT;
 
-  const { settings } = useUserStore();
-
+  const buttonLabel = SETTING_TITLES[settingType];
   const updateSetting = useUpdateSetting(settingType);
 
   const handleToggle = () => {

--- a/src/pages/ChannelPlayer.jsx
+++ b/src/pages/ChannelPlayer.jsx
@@ -6,15 +6,17 @@ import { SETTING_TITLES, SETTING_TYPES } from "@/constants/settingOptions";
 import useAdKeywordsSocketListener from "@/hooks/useAdKeywordsSocketListener";
 import useChannelPlayback from "@/hooks/useChannelPlayback";
 import useUpdateSetting from "@/hooks/useUpdateSetting";
+import { useChannelStore } from "@/store/useChannelStore";
 import { useUserStore } from "@/store/useUserStore";
 
-const ChannelPlayer = ({ isChannelChanged }) => {
+const ChannelPlayer = () => {
   const { videoId, selectedChannel, isPlaying, handlePlayPause } =
     useChannelPlayback("full");
   const { name, logoUrl } = selectedChannel;
 
   useAdKeywordsSocketListener(videoId);
 
+  const isChannelChanged = useChannelStore((state) => state.isChannelChanged);
   const buttonLabel = isChannelChanged
     ? SETTING_TITLES[SETTING_TYPES.RETURN_CHANNEL]
     : SETTING_TITLES[SETTING_TYPES.AD_DETECT];

--- a/src/store/useChannelStore.js
+++ b/src/store/useChannelStore.js
@@ -5,12 +5,14 @@ export const useChannelStore = create(
   persist(
     (set) => ({
       interestChannelIds: [],
+      isChannelChanged: false,
       prevChannelId: null,
       radioChannelList: [],
       selectedChannelId: null,
 
       setInterestChannelIds: (interestChannelIds) =>
         set({ interestChannelIds }),
+      setIsChannelChanged: (isChanged) => set({ isChannelChanged: isChanged }),
       setPrevChannelId: (channelId) => set({ prevChannelId: channelId }),
       setRadioChannelList: (channelList) =>
         set({ radioChannelList: channelList }),

--- a/src/store/useMiniPlayerStore.js
+++ b/src/store/useMiniPlayerStore.js
@@ -4,6 +4,7 @@ export const useMiniPlayerStore = create((set) => ({
   isVisible: false,
   playingChannelId: null,
 
+  setPlayingChannelId: (channelId) => set({ playingChannelId: channelId }),
   openMiniPlayer: (channelId) =>
     set({ isVisible: true, playingChannelId: channelId }),
 

--- a/src/utils/playControl.js
+++ b/src/utils/playControl.js
@@ -2,8 +2,8 @@ import Hls from "hls.js";
 
 import { getChannelInfo } from "@/apis/radioChannels";
 
-let hlsInstance = null;
 const userId = localStorage.getItem("userId");
+let hlsInstance = null;
 
 export const startStreamingPlay = (video, url) => {
   if (hlsInstance) {
@@ -39,14 +39,5 @@ export const controlStreamingPlayback = async (
     }
   } else {
     video.pause();
-  }
-};
-
-export const controlStreamingSwitch = async (video, channelId, isAdDetect) => {
-  try {
-    const { data } = await getChannelInfo(channelId, isAdDetect, userId);
-    startStreamingPlay(video, data.url);
-  } catch (error) {
-    console.error("fetch channelInfo failed", error);
   }
 };


### PR DESCRIPTION
### ✨ 이슈 번호

- #98

### 📌 설명

- 광고 감지 시 플레이어 채널 정보 변경을 구현하여 작성한 Pull Request입니다.
정보 변경을 위해 "광고 감지 재생 로직"에 플레이어 리렌더링 기능을 추가합니다.

### 📃 작업 사항

- [x] 재생 로직에 플레이어 리렌더링 기능을 추가
  - [x] playControl에서 useControlStreamingSwitch 훅 분리
- [x] 채널 상태 관리 store에 isChannelChanged 추가
- [x]  미니 플레이어 상태 관리 Store에 setPlayingChannelId 함수 추가

### 💭 리뷰 사항 반영

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
