### PR TITLE
fix: 사용자가 채널 이동할 때 isChannelChanged 초기화

### DIFF
--- a/src/hooks/useChannelNavigation.jsx
+++ b/src/hooks/useChannelNavigation.jsx
@@ -7,9 +7,13 @@ const useChannelNavigation = () => {
   const setSelectedChannelId = useChannelStore(
     (state) => state.setSelectedChannelId
   );
+  const setIsChannelChanged = useChannelStore(
+    (state) => state.setIsChannelChanged
+  );
 
   const goToChannelPlayer = (channelId) => {
     setSelectedChannelId(channelId);
+    setIsChannelChanged(false);
     navigate("/channel-player");
   };
 


### PR DESCRIPTION
### ✨ 이슈 번호

- #102

### 📌 설명

- 사용자가 직접 채널을 선택해 이동한 경우 isChannelChanged를 false로 초기화를 구현하여 작성한 Pull Request입니다.
자동 채널 전환이 일어난 경우 isChannelChanged를 true로 설정하도록 되어 있으나, 사용자가 직접 채널을 선택한 경우에도 이전 상태가 유지되어 잘못된 UI 상태가 나타나는 문제를 해결합니다.

### 📃 작업 사항

- [x] 사용자가 채널 이동 시 isChannelChanged를 false로 초기화

### 💭 리뷰 사항 반영

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
