### PR TITLE
fix: 사용자 재생 요청 채널에만 Whisper 서버 호출되도록 로직 개선

### DIFF
--- a/src/apis/radioChannels.js
+++ b/src/apis/radioChannels.js
@@ -1,8 +1,8 @@
 import axiosInstance from "@/apis/axiosInstance";
 
-export const getChannelInfo = (channelId, isAdDetect, userId) =>
+export const getChannelInfo = (channelId, userId) =>
   axiosInstance.get(`/radio-channels/${channelId}`, {
-    params: { isAdDetect, userId },
+    params: { userId },
   });
 
 export const getRandomNoAdChannel = () =>

--- a/src/hooks/useControlStreamingSwitch.jsx
+++ b/src/hooks/useControlStreamingSwitch.jsx
@@ -13,10 +13,10 @@ const useControlStreamingSwitch = () => {
     setIsChannelChanged(true);
   };
 
-  const controlStreamingSwitch = async (video, channelId, isAdDetect) => {
+  const controlStreamingSwitch = async (video, channelId) => {
     const userId = localStorage.getItem("userId");
     try {
-      const { data } = await getChannelInfo(channelId, isAdDetect, userId);
+      const { data } = await getChannelInfo(channelId, userId);
       startStreamingPlay(video, data.url);
       updateChannelState(channelId);
     } catch (error) {

--- a/src/utils/playControl.js
+++ b/src/utils/playControl.js
@@ -25,16 +25,12 @@ export const startStreamingPlay = (video, url) => {
   }
 };
 
-export const controlStreamingPlayback = async (
-  video,
-  channelId,
-  isPlaying,
-  isAdDetect
-) => {
+export const controlStreamingPlayback = async (video, channelId, isPlaying) => {
   if (!isPlaying) {
     try {
-      const { data } = await getChannelInfo(channelId, isAdDetect, userId);
-      startStreamingPlay(video, data.url);
+      const { data } = await getChannelInfo(channelId, userId);
+      const streamingUrl = data.url;
+      startStreamingPlay(video, streamingUrl);
     } catch (error) {
       console.error("fetch channelInfo failed", error);
     }

--- a/src/utils/playControl.js
+++ b/src/utils/playControl.js
@@ -25,11 +25,23 @@ export const startStreamingPlay = (video, url) => {
   }
 };
 
-export const controlStreamingPlayback = async (video, channelId, isPlaying) => {
+export const controlStreamingPlayback = async (
+  video,
+  channelId,
+  isPlaying,
+  isAdDetect
+) => {
   if (!isPlaying) {
     try {
       const { data } = await getChannelInfo(channelId, userId);
       const streamingUrl = data.url;
+      if (isAdDetect) {
+        await axios.post("http://localhost:3000/whisper", {
+          streamingUrl,
+          userId,
+          channelId,
+        });
+      }
       startStreamingPlay(video, streamingUrl);
     } catch (error) {
       console.error("fetch channelInfo failed", error);


### PR DESCRIPTION
### ✨ 이슈 번호

- #106 

### 📌 설명 

- 사용자가 라디오 재생 버튼을 누른 채널에서만 Whisper 서버가 호출되도록 처리한 Pull Request입니다.
- 광고 감지 후 자동으로 이동한 채널에서는 Whisper 호출을 생략하여 중복 실행을 방지합니다.

### 📃 작업 사항

- [x] 사용자가 재생 버튼을 누른 채널에서만 Whisper 서버 호출
- [x] 광고 감지 후 이동한 채널에서는 Whisper 서버 호출 생략
- [x] `getChannelInfo`를 채널 정보 조회 역할로 관심사 분리 (Whisper 호출 함수 별도 추출)

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
