### PR TITLE
fix: 광고 감지 후 사용자 채널 복귀 로직 오류 수정

### DIFF
--- a/src/hooks/useChannelSwitch.jsx
+++ b/src/hooks/useChannelSwitch.jsx
@@ -8,6 +8,7 @@ import { useUserStore } from "@/store/useUserStore";
 
 const useChannelSwitch = (videoRef) => {
   const prevChannelId = useChannelStore((state) => state.prevChannelId);
+  const selectedChannelId = useChannelStore((state) => state.selectedChannelId);
   const setPrevChannelId = useChannelStore((state) => state.setPrevChannelId);
   const controlStreamingSwitch = useControlStreamingSwitch();
   const { settings } = useUserStore();
@@ -21,7 +22,7 @@ const useChannelSwitch = (videoRef) => {
           try {
             const { data } = await getRandomNoAdChannel();
             channelId = data.id;
-            setPrevChannelId(channelId);
+            setPrevChannelId(selectedChannelId);
           } catch (error) {
             console.error("fetch randomNoAdchannel failed", error);
           }
@@ -41,6 +42,7 @@ const useChannelSwitch = (videoRef) => {
     },
     [
       prevChannelId,
+      selectedChannelId,
       setPrevChannelId,
       isAdDetect,
       videoRef,


### PR DESCRIPTION
### ✨ 이슈 번호

- #108 

### 📌 설명

- 광고 감지 후 사용자 채널 복귀 로직 오류를 수정하여 작성한 Pull Request입니다.
- 오류 : 광고 감지 시 원래 채널이 아닌 랜덤 채널로 고정되는 버그입니다.

### 📃 작업 사항

- [x] `selectedChannelId`를 이용해 광고 중 이동한 채널 이전 상태로 저장

### 💭 리뷰 사항 반영

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
