### PR TITLE
fix: “기존 채널로 이동” 설정이 새로고침 시 초기화되는 문제 수정

### DIFF
--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -5,8 +5,7 @@ import {
   SETTING_TITLES,
   SETTING_EXPLANATIONS,
 } from "@/constants/settingOptions";
-
-import useUserProfile from "../hooks/useUserProfile";
+import useUserProfile from "@/hooks/useUserProfile";
 
 const Settings = () => {
   const settingTypes = Object.values(SETTING_TYPES);

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -5,13 +5,9 @@ import {
   SETTING_TITLES,
   SETTING_EXPLANATIONS,
 } from "@/constants/settingOptions";
-import useUserProfile from "@/hooks/useUserProfile";
 
 const Settings = () => {
   const settingTypes = Object.values(SETTING_TYPES);
-
-  const userId = localStorage.getItem("userId");
-  useUserProfile(userId);
 
   return (
     <>

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -6,8 +6,13 @@ import {
   SETTING_EXPLANATIONS,
 } from "@/constants/settingOptions";
 
+import useUserProfile from "../hooks/useUserProfile";
+
 const Settings = () => {
   const settingTypes = Object.values(SETTING_TYPES);
+
+  const userId = localStorage.getItem("userId");
+  useUserProfile(userId);
 
   return (
     <>

--- a/src/store/useUserStore.js
+++ b/src/store/useUserStore.js
@@ -1,11 +1,19 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 
-export const useUserStore = create((set) => ({
-  settings: {
-    isAdDetect: true,
-    isReturnChannel: false,
-  },
+export const useUserStore = create(
+  persist(
+    (set) => ({
+      setting: {
+        isAdDetect: true,
+        isReturnChannel: false,
+      },
 
-  setUserSettings: ({ isAdDetect, isReturnChannel }) =>
-    set({ settings: { isAdDetect, isReturnChannel } }),
-}));
+      setUserSettings: ({ isAdDetect, isReturnChannel }) =>
+        set({ settings: { isAdDetect, isReturnChannel } }),
+    }),
+    {
+      name: "user-settings",
+    }
+  )
+);


### PR DESCRIPTION
### ✨ 이슈 번호 

- #110 

### 📌 설명

- 사용자가 settings 페이지에서 “기존 채널로 이동” 설정을 켜도 페이지를 새로고침하면 해당 설정이 다시 꺼진 상태로 초기화되는 문제를 수정한 Pull Request입니다.


### 📃 작업 사항

- [x] `useUserProfile` 훅을 Settings 페이지에 추가하여 사용자 설정값을 서버에서 불러오도록 수정
- [x] 새로고침 시에도 `isAdDetect`, `isReturnChannel` 설정값이 유지되도록 변경

### 💡 참고 사항 


https://github.com/user-attachments/assets/c219687e-d91d-4010-9a8d-0661ea93ccab

### 💭 리뷰 사항 반영 

- [x] persist 적용으로 불필요해진 useUserProfile 호출 제거
  - zustand persist로 설정값을 localStorage에 저장하도록 개선됨에 따라, Settings 페이지에서 더 이상 useUserProfile를 호출할 필요가    없어 해당 로직 제거
  
### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
