### PR TITLE
feat: MiniPlayer 종료 시 Whisper 서버 중단 처리 추가

### DIFF
--- a/src/components/MiniPlayer.jsx
+++ b/src/components/MiniPlayer.jsx
@@ -4,6 +4,7 @@ import PlayIcon from "@/assets/svgs/icon-mini-play.svg?react";
 import useChannelPlayback from "@/hooks/useChannelPlayback";
 import { useMiniPlayerStore } from "@/store/useMiniPlayerStore";
 import { usePlayingStore } from "@/store/usePlayingStore";
+import { stopWhisperServer } from "@/utils/stopWhisperServer";
 import { getGlobalVideo } from "@/utils/videoElement";
 
 const MiniPlayer = () => {
@@ -19,6 +20,9 @@ const MiniPlayer = () => {
     video.src = "";
     setIsPlaying(false);
     closeMiniPlayer();
+
+    const userId = localStorage.getItem("userId");
+    stopWhisperServer(userId);
   };
 
   return (

--- a/src/utils/playControl.js
+++ b/src/utils/playControl.js
@@ -2,6 +2,7 @@ import axios from "axios";
 import Hls from "hls.js";
 
 import { getChannelInfo } from "@/apis/radioChannels";
+import { stopWhisperServer } from "@/utils/stopWhisperServer";
 
 const userId = localStorage.getItem("userId");
 let hlsInstance = null;
@@ -49,14 +50,5 @@ export const controlStreamingPlayback = async (
   } else {
     video.pause();
     stopWhisperServer(userId);
-  }
-};
-
-const stopWhisperServer = async (userId) => {
-  try {
-    // 추후 배포 시 변경
-    await axios.post("http://localhost:5000/stop", { userId });
-  } catch (error) {
-    console.error("❌ Whisper 종료 실패", error);
   }
 };

--- a/src/utils/stopWhisperServer.js
+++ b/src/utils/stopWhisperServer.js
@@ -1,0 +1,10 @@
+import axios from "axios";
+
+export const stopWhisperServer = async (userId) => {
+  try {
+    // 추후 배포 시 변경
+    await axios.post("http://localhost:5000/stop", { userId });
+  } catch (error) {
+    console.error("❌ Whisper 종료 실패", error);
+  }
+};


### PR DESCRIPTION
### ✨ 이슈 번호

- #112 

### 📌 설명

- MiniPlayer에서 닫기 버튼을 누를 경우 Whisper 서버 중단하는 로직을 추가하여 작성한 Pull Request입니다.
- `playControl.js`에 존재하던 `stopWhisperServer` 함수를 분리하여 재사용합니다.

### 📃 작업 사항

- [x] MiniPlayer에서 닫기 버튼 누를 경우 Whisper 서버 중단
  - [x] stopWhisperServer 함수 유틸로 분리하여 MiniPlayer에서 재사용

### 💭 리뷰 사항 반영

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
