### PR TITLE
refactor: 광고 감지 로직 전역화 및 video 엘리먼트 전역 상태 관리로 전환

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,11 +2,14 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { RouterProvider } from "react-router-dom";
 
+import useAdKeywordsSocketListener from "@/hooks/useAdKeywordsSocketListener";
 import router from "@/routes";
 
 const queryClient = new QueryClient();
 
 const App = () => {
+  useAdKeywordsSocketListener();
+
   return (
     <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />

--- a/src/components/MiniPlayer.jsx
+++ b/src/components/MiniPlayer.jsx
@@ -4,10 +4,11 @@ import PlayIcon from "@/assets/svgs/icon-mini-play.svg?react";
 import useChannelPlayback from "@/hooks/useChannelPlayback";
 import { useMiniPlayerStore } from "@/store/useMiniPlayerStore";
 import { usePlayingStore } from "@/store/usePlayingStore";
+import { useVideoElementStore } from "@/store/useVideoElementStore";
 import { stopWhisperServer } from "@/utils/stopWhisperServer";
-import { getGlobalVideo } from "@/utils/videoElement";
 
 const MiniPlayer = () => {
+  const videoElement = useVideoElementStore((state) => state.videoElement);
   const { selectedChannel, isPlaying, handlePlayPause } =
     useChannelPlayback("mini");
   const { closeMiniPlayer } = useMiniPlayerStore();
@@ -15,9 +16,8 @@ const MiniPlayer = () => {
   const { name, logoUrl } = selectedChannel;
 
   const handleClose = () => {
-    const video = getGlobalVideo();
-    video.pause();
-    video.src = "";
+    videoElement.pause();
+    videoElement.src = "";
     setIsPlaying(false);
     closeMiniPlayer();
 

--- a/src/hooks/useAdKeywordsSocketListener.jsx
+++ b/src/hooks/useAdKeywordsSocketListener.jsx
@@ -4,8 +4,8 @@ import useChannelSwitch from "@/hooks/useChannelSwitch";
 import useUserId from "@/hooks/useUserId";
 import socket from "@/sockets/socketClient";
 
-const useAdKeywordsSocketListener = (videoId) => {
-  const handleChannelSwitch = useChannelSwitch(videoId);
+const useAdKeywordsSocketListener = () => {
+  const handleChannelSwitch = useChannelSwitch();
   const userId = useUserId();
 
   useEffect(() => {

--- a/src/hooks/useAdKeywordsSocketListener.jsx
+++ b/src/hooks/useAdKeywordsSocketListener.jsx
@@ -6,16 +6,16 @@ import socket from "@/sockets/socketClient";
 
 const useAdKeywordsSocketListener = () => {
   const handleChannelSwitch = useChannelSwitch();
-  const userId = useUserId();
+  const userId = Number(useUserId());
 
   useEffect(() => {
-    if (!userId) {
+    if (Number.isNaN(userId)) {
       return;
     }
 
     const handleConnect = () => {
       console.log("connected");
-      socket.emit("registerUser", { userId });
+      socket.emit("registerUser", { userId: String(userId) });
     };
 
     const handleRadioText = ({ isAd }) => {
@@ -26,13 +26,13 @@ const useAdKeywordsSocketListener = () => {
       console.log("disconnected");
     };
 
-    socket.on("connect", handleConnect);
-    socket.on("radioText", handleRadioText);
-    socket.on("disconnect", handleDisconnect);
-
     if (socket.connected) {
       handleConnect();
     }
+
+    socket.on("connect", handleConnect);
+    socket.on("radioText", handleRadioText);
+    socket.on("disconnect", handleDisconnect);
 
     return () => {
       socket.off("connect", handleConnect);

--- a/src/hooks/useChannelPlayback.jsx
+++ b/src/hooks/useChannelPlayback.jsx
@@ -3,15 +3,15 @@ import { useChannelStore } from "@/store/useChannelStore";
 import { useMiniPlayerStore } from "@/store/useMiniPlayerStore";
 import { usePlayingStore } from "@/store/usePlayingStore";
 import { useUserStore } from "@/store/useUserStore";
+import { useVideoElementStore } from "@/store/useVideoElementStore";
 import { controlStreamingPlayback } from "@/utils/playControl";
-import { getGlobalVideo } from "@/utils/videoElement";
 
 const useChannelPlayback = (mode) => {
+  const videoElement = useVideoElementStore((state) => state.videoElement);
   const { selectedChannelId, radioChannelList } = useChannelStore();
   const { playingChannelId, openMiniPlayer } = useMiniPlayerStore();
   const { isPlaying, setIsPlaying } = usePlayingStore();
   const { settings } = useUserStore();
-  const video = getGlobalVideo();
   const isAdDetect = settings[SETTING_TYPES.AD_DETECT];
 
   const isMiniMode = mode === "mini";
@@ -27,17 +27,21 @@ const useChannelPlayback = (mode) => {
 
   const handlePlayPause = () => {
     if (!isCurrentPlaying) {
-      controlStreamingPlayback(video, targetChannelId, false, isAdDetect);
+      controlStreamingPlayback(
+        videoElement,
+        targetChannelId,
+        false,
+        isAdDetect
+      );
       openMiniPlayer(targetChannelId);
       setIsPlaying(true);
     } else {
-      controlStreamingPlayback(video, targetChannelId, true, isAdDetect);
+      controlStreamingPlayback(videoElement, targetChannelId, true, isAdDetect);
       setIsPlaying(false);
     }
   };
 
   return {
-    videoId: video,
     selectedChannel,
     isPlaying: isCurrentPlaying,
     handlePlayPause,

--- a/src/hooks/useChannelSwitch.jsx
+++ b/src/hooks/useChannelSwitch.jsx
@@ -5,8 +5,10 @@ import { SETTING_TYPES } from "@/constants/settingOptions";
 import useControlStreamingSwitch from "@/hooks/useControlStreamingSwitch";
 import { useChannelStore } from "@/store/useChannelStore";
 import { useUserStore } from "@/store/useUserStore";
+import { useVideoElementStore } from "@/store/useVideoElementStore";
 
-const useChannelSwitch = (videoRef) => {
+const useChannelSwitch = () => {
+  const videoElement = useVideoElementStore((state) => state.videoElement);
   const prevChannelId = useChannelStore((state) => state.prevChannelId);
   const selectedChannelId = useChannelStore((state) => state.selectedChannelId);
   const setIsChannelChanged = useChannelStore(
@@ -40,7 +42,7 @@ const useChannelSwitch = (videoRef) => {
           setPrevChannelId(null);
         }
 
-        await controlStreamingSwitch(videoRef, channelId, isAdDetect);
+        await controlStreamingSwitch(videoElement, channelId, isAdDetect);
       } catch (error) {
         console.error("switch failed: ", error);
       }
@@ -51,7 +53,7 @@ const useChannelSwitch = (videoRef) => {
       setIsChannelChanged,
       setPrevChannelId,
       isAdDetect,
-      videoRef,
+      videoElement,
       controlStreamingSwitch,
     ]
   );

--- a/src/hooks/useChannelSwitch.jsx
+++ b/src/hooks/useChannelSwitch.jsx
@@ -1,10 +1,8 @@
 import { useCallback } from "react";
 
 import { getRandomNoAdChannel } from "@/apis/radioChannels";
-import { SETTING_TYPES } from "@/constants/settingOptions";
 import useControlStreamingSwitch from "@/hooks/useControlStreamingSwitch";
 import { useChannelStore } from "@/store/useChannelStore";
-import { useUserStore } from "@/store/useUserStore";
 import { useVideoElementStore } from "@/store/useVideoElementStore";
 
 const useChannelSwitch = () => {
@@ -16,8 +14,6 @@ const useChannelSwitch = () => {
   );
   const setPrevChannelId = useChannelStore((state) => state.setPrevChannelId);
   const controlStreamingSwitch = useControlStreamingSwitch();
-  const { settings } = useUserStore();
-  const isAdDetect = settings[SETTING_TYPES.AD_DETECT];
 
   const handleChannelSwitch = useCallback(
     async (isAd) => {
@@ -42,7 +38,7 @@ const useChannelSwitch = () => {
           setPrevChannelId(null);
         }
 
-        await controlStreamingSwitch(videoElement, channelId, isAdDetect);
+        await controlStreamingSwitch(videoElement, channelId);
       } catch (error) {
         console.error("switch failed: ", error);
       }
@@ -52,7 +48,6 @@ const useChannelSwitch = () => {
       selectedChannelId,
       setIsChannelChanged,
       setPrevChannelId,
-      isAdDetect,
       videoElement,
       controlStreamingSwitch,
     ]

--- a/src/hooks/useControlStreamingSwitch.jsx
+++ b/src/hooks/useControlStreamingSwitch.jsx
@@ -12,11 +12,11 @@ const useControlStreamingSwitch = () => {
     setPlayingChannelId(channelId);
   };
 
-  const controlStreamingSwitch = async (video, channelId) => {
+  const controlStreamingSwitch = async (videoElement, channelId) => {
     const userId = localStorage.getItem("userId");
     try {
       const { data } = await getChannelInfo(channelId, userId);
-      startStreamingPlay(video, data.url);
+      startStreamingPlay(videoElement, data.url);
       updateChannelState(channelId);
     } catch (error) {
       console.error("fetch channelInfo failed", error);

--- a/src/layout/MainLayout.jsx
+++ b/src/layout/MainLayout.jsx
@@ -17,7 +17,7 @@ const MainLayout = () => {
     if (videoRef.current) {
       setVideoElement(videoRef.current);
     }
-  }, []);
+  }, [setVideoElement]);
 
   return (
     <div className="flex justify-center bg-purple-50">

--- a/src/layout/MainLayout.jsx
+++ b/src/layout/MainLayout.jsx
@@ -1,11 +1,23 @@
+import { useEffect, useRef } from "react";
 import { Outlet } from "react-router-dom";
 
 import Header from "@/components/header";
 import MiniPlayer from "@/components/MiniPlayer";
 import { useMiniPlayerStore } from "@/store/useMiniPlayerStore";
+import { useVideoElementStore } from "@/store/useVideoElementStore";
 
 const MainLayout = () => {
+  const videoRef = useRef(null);
   const isVisible = useMiniPlayerStore((state) => state.isVisible);
+  const setVideoElement = useVideoElementStore(
+    (state) => state.setVideoElement
+  );
+
+  useEffect(() => {
+    if (videoRef.current) {
+      setVideoElement(videoRef.current);
+    }
+  }, []);
 
   return (
     <div className="flex justify-center bg-purple-50">
@@ -15,6 +27,7 @@ const MainLayout = () => {
           <Outlet />
         </main>
         <video
+          ref={videoRef}
           id="global-radio"
           className="hidden"
           playsInline

--- a/src/layout/MainLayout.jsx
+++ b/src/layout/MainLayout.jsx
@@ -28,7 +28,6 @@ const MainLayout = () => {
         </main>
         <video
           ref={videoRef}
-          id="global-radio"
           className="hidden"
           playsInline
           autoPlay

--- a/src/pages/ChannelPlayer.jsx
+++ b/src/pages/ChannelPlayer.jsx
@@ -3,18 +3,16 @@ import MainPlayIcon from "@/assets/svgs/icon-main-play.svg?react";
 import Button from "@/components/ui/Button";
 import ToggleButton from "@/components/ui/ToggleButton";
 import { SETTING_TITLES, SETTING_TYPES } from "@/constants/settingOptions";
-import useAdKeywordsSocketListener from "@/hooks/useAdKeywordsSocketListener";
 import useChannelPlayback from "@/hooks/useChannelPlayback";
 import useUpdateSetting from "@/hooks/useUpdateSetting";
 import { useChannelStore } from "@/store/useChannelStore";
 import { useUserStore } from "@/store/useUserStore";
 
 const ChannelPlayer = () => {
-  const { videoId, selectedChannel, isPlaying, handlePlayPause } =
+  const { selectedChannel, isPlaying, handlePlayPause } =
     useChannelPlayback("full");
   const isChannelChanged = useChannelStore((state) => state.isChannelChanged);
   const { settings } = useUserStore();
-  useAdKeywordsSocketListener(videoId);
 
   const { name, logoUrl } = selectedChannel;
 

--- a/src/store/useVideoElementStore.js
+++ b/src/store/useVideoElementStore.js
@@ -1,0 +1,7 @@
+import { create } from "zustand";
+
+export const useVideoElementStore = create((set) => ({
+  videoElement: null,
+
+  setVideoElement: (videoElement) => set({ videoElement }),
+}));

--- a/src/utils/videoElement.js
+++ b/src/utils/videoElement.js
@@ -1,1 +1,0 @@
-export const getGlobalVideo = () => document.getElementById("global-radio");


### PR DESCRIPTION
### ✨ 이슈 번호

- #115 

### 📌 설명

- 광고 감지 소켓 연결 기능을 상단에서 안정적으로 유지하고, video 엘리먼트 접근 방식의 일관성을 높이기 위한 작업을 구현한 Pull Request입니다.
- 여러 페이지 전환 시에도 소켓 연결 및 video 접근 안정성을 확보합니다.
- videoElement 관련 로직 도입 중 발견된 사항도 리팩토링하였습니다.

### 📃 작업 사항

- [x] 광고 감지 소켓 연결 훅(`useAdKeywordsSocketListener`)을 App 컴포넌트로 이동하여 전역에서 감지 가능하도록 변경
- [x] video 엘리먼트를 전역으로 관리하기 위한 `useVideoElementStore` 추가
  - [x] video getElementById를 `useRef`+`useVideoElementStore`로 관리하도록 구조 개선
  - [x] 기존 컴포넌트들에서 store 기반 `videoElement`로 대체
  - [x] getGlobalVideo 함수 제거

- [x] videoElement 관련 로직 도입 중 발견된 사항 리팩토링
  - [x] useAdKeywordsSocketListener
    - [x] userId가 0일 경우를 고려하여 조건 검사 방식 개선
    - [x] socket 수동 호출 순서 조정으로 안정성 향상
  - [x] useChannelSwitch
    - [x] controlStreamingSwitch 매개변수 변경에 따라 isAdDetect 제거

### 💭 리뷰 사항 반영

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
