### PR TITLE
chore: Whisper 및 백엔드 서버용 환경 변수 설정

### DIFF
--- a/src/apis/axiosInstance.js
+++ b/src/apis/axiosInstance.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const instance = axios.create({
-  baseURL: import.meta.env.VITE_API_URL,
+  baseURL: import.meta.env.VITE_BACKEND_API_URL,
   headers: {
     "Content-Type": "application/json",
   },

--- a/src/apis/axiosInstance.js
+++ b/src/apis/axiosInstance.js
@@ -1,7 +1,9 @@
 import axios from "axios";
 
+import { BACKEND_API_URL } from "@/constants/env";
+
 const instance = axios.create({
-  baseURL: import.meta.env.VITE_BACKEND_API_URL,
+  baseURL: BACKEND_API_URL,
   headers: {
     "Content-Type": "application/json",
   },

--- a/src/constants/env.js
+++ b/src/constants/env.js
@@ -1,0 +1,2 @@
+export const BACKEND_API_URL = import.meta.env.VITE_BACKEND_API_URL;
+export const WHISPER_API_URL = import.meta.env.VITE_WHISPER_API_URL;

--- a/src/hooks/useChannels.jsx
+++ b/src/hooks/useChannels.jsx
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { useEffect } from "react";
 
+import { BACKEND_API_URL } from "@/constants/env";
 import { useChannelStore } from "@/store/useChannelStore";
 
 const useChannels = () => {
@@ -13,9 +14,7 @@ const useChannels = () => {
 
     const initChannels = async () => {
       try {
-        const { data } = await axios.get(
-          `${import.meta.env.VITE_BACKEND_API_URL}/radio-channels`
-        );
+        const { data } = await axios.get(`${BACKEND_API_URL}/radio-channels`);
         setRadioChannelList(data);
       } catch (error) {
         console.error("fetch radioChannels failed: ", error);

--- a/src/hooks/useChannels.jsx
+++ b/src/hooks/useChannels.jsx
@@ -14,7 +14,7 @@ const useChannels = () => {
     const initChannels = async () => {
       try {
         const { data } = await axios.get(
-          `${import.meta.env.VITE_API_URL}/radio-channels`
+          `${import.meta.env.VITE_BACKEND_API_URL}/radio-channels`
         );
         setRadioChannelList(data);
       } catch (error) {

--- a/src/hooks/useInterestChannels.jsx
+++ b/src/hooks/useInterestChannels.jsx
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { useEffect } from "react";
 
+import { BACKEND_API_URL } from "@/constants/env";
 import { useChannelStore } from "@/store/useChannelStore";
 
 const useInterestChannels = (userId) => {
@@ -16,7 +17,7 @@ const useInterestChannels = (userId) => {
     const getInterestIds = async () => {
       try {
         const { data } = await axios.get(
-          `${import.meta.env.VITE_BACKEND_API_URL}/users/${userId}/interest-channels`
+          `${BACKEND_API_URL}/users/${userId}/interest-channels`
         );
         const ids = data.map((item) => item.channelId);
         setInterestChannelIds(ids);

--- a/src/hooks/useInterestChannels.jsx
+++ b/src/hooks/useInterestChannels.jsx
@@ -16,7 +16,7 @@ const useInterestChannels = (userId) => {
     const getInterestIds = async () => {
       try {
         const { data } = await axios.get(
-          `${import.meta.env.VITE_API_URL}/users/${userId}/interest-channels`
+          `${import.meta.env.VITE_BACKEND_API_URL}/users/${userId}/interest-channels`
         );
         const ids = data.map((item) => item.channelId);
         setInterestChannelIds(ids);

--- a/src/hooks/useSubmitAdReport.jsx
+++ b/src/hooks/useSubmitAdReport.jsx
@@ -1,17 +1,16 @@
 import axios from "axios";
 
+import { BACKEND_API_URL } from "@/constants/env";
+
 const useSubmitAdReport = () => {
   const reportAd = async ({ userId, isAd, detectedAdPhrase, channelId }) => {
     try {
-      const { data } = await axios.post(
-        `${import.meta.env.VITE_BACKEND_API_URL}/reports`,
-        {
-          userId,
-          isAd,
-          detectedAdPhrase,
-          channelId,
-        }
-      );
+      const { data } = await axios.post(`${BACKEND_API_URL}/reports`, {
+        userId,
+        isAd,
+        detectedAdPhrase,
+        channelId,
+      });
 
       return data;
     } catch (error) {

--- a/src/hooks/useSubmitAdReport.jsx
+++ b/src/hooks/useSubmitAdReport.jsx
@@ -4,7 +4,7 @@ const useSubmitAdReport = () => {
   const reportAd = async ({ userId, isAd, detectedAdPhrase, channelId }) => {
     try {
       const { data } = await axios.post(
-        `${import.meta.env.VITE_API_URL}/reports`,
+        `${import.meta.env.VITE_BACKEND_API_URL}/reports`,
         {
           userId,
           isAd,

--- a/src/hooks/useUpdateSetting.jsx
+++ b/src/hooks/useUpdateSetting.jsx
@@ -23,7 +23,7 @@ const useUpdateSetting = (type) => {
 
     try {
       await axios.put(
-        `${import.meta.env.VITE_API_URL}/users/${userId}/settings`,
+        `${import.meta.env.VITE_BACKEND_API_URL}/users/${userId}/settings`,
         updatedSettings
       );
       setUserSettings(updatedSettings);

--- a/src/hooks/useUpdateSetting.jsx
+++ b/src/hooks/useUpdateSetting.jsx
@@ -1,5 +1,6 @@
 import axios from "axios";
 
+import { BACKEND_API_URL } from "@/constants/env";
 import { SETTING_TYPES } from "@/constants/settingOptions";
 import { useUserStore } from "@/store/useUserStore";
 
@@ -23,7 +24,7 @@ const useUpdateSetting = (type) => {
 
     try {
       await axios.put(
-        `${import.meta.env.VITE_BACKEND_API_URL}/users/${userId}/settings`,
+        `${BACKEND_API_URL}/users/${userId}/settings`,
         updatedSettings
       );
       setUserSettings(updatedSettings);

--- a/src/hooks/useUserId.jsx
+++ b/src/hooks/useUserId.jsx
@@ -12,7 +12,7 @@ const useUserId = () => {
         try {
           const {
             data: { userId },
-          } = await axios.post(`${import.meta.env.VITE_API_URL}/users`);
+          } = await axios.post(`${import.meta.env.VITE_BACKEND_API_URL}/users`);
           localStorage.setItem("userId", userId);
         } catch (error) {
           console.error("fetch userId failed: ", error);

--- a/src/hooks/useUserId.jsx
+++ b/src/hooks/useUserId.jsx
@@ -1,6 +1,8 @@
 import axios from "axios";
 import { useEffect, useState } from "react";
 
+import { BACKEND_API_URL } from "@/constants/env";
+
 const useUserId = () => {
   const [userId, setUserId] = useState(null);
 
@@ -12,7 +14,7 @@ const useUserId = () => {
         try {
           const {
             data: { userId },
-          } = await axios.post(`${import.meta.env.VITE_BACKEND_API_URL}/users`);
+          } = await axios.post(`${BACKEND_API_URL}/users`);
           localStorage.setItem("userId", userId);
         } catch (error) {
           console.error("fetch userId failed: ", error);

--- a/src/hooks/useUserProfile.jsx
+++ b/src/hooks/useUserProfile.jsx
@@ -14,7 +14,7 @@ const useUserProfile = (userId) => {
     const initUserProfile = async () => {
       try {
         const response = await axios.get(
-          `${import.meta.env.VITE_API_URL}/users/${userId}`
+          `${import.meta.env.VITE_BACKEND_API_URL}/users/${userId}`
         );
         const { isAdDetect, isReturnChannel } = response.data;
         setUserSettings({ isAdDetect, isReturnChannel });

--- a/src/hooks/useUserProfile.jsx
+++ b/src/hooks/useUserProfile.jsx
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { useEffect } from "react";
 
+import { BACKEND_API_URL } from "@/constants/env";
 import { useUserStore } from "@/store/useUserStore";
 
 const useUserProfile = (userId) => {
@@ -13,9 +14,7 @@ const useUserProfile = (userId) => {
 
     const initUserProfile = async () => {
       try {
-        const response = await axios.get(
-          `${import.meta.env.VITE_BACKEND_API_URL}/users/${userId}`
-        );
+        const response = await axios.get(`${BACKEND_API_URL}/users/${userId}`);
         const { isAdDetect, isReturnChannel } = response.data;
         setUserSettings({ isAdDetect, isReturnChannel });
       } catch (error) {

--- a/src/sockets/socketClient.js
+++ b/src/sockets/socketClient.js
@@ -1,6 +1,7 @@
 import { io } from "socket.io-client";
 
-// TODO: 추후 서버 배포 시 주소 변경
-const socket = io(import.meta.env.VITE_BACKEND_API_URL);
+import { BACKEND_API_URL } from "@/constants/env";
+
+const socket = io(BACKEND_API_URL);
 
 export default socket;

--- a/src/sockets/socketClient.js
+++ b/src/sockets/socketClient.js
@@ -1,6 +1,6 @@
 import { io } from "socket.io-client";
 
 // TODO: 추후 서버 배포 시 주소 변경
-const socket = io("http://localhost:3000");
+const socket = io(import.meta.env.VITE_BACKEND_API_URL);
 
 export default socket;

--- a/src/utils/playControl.js
+++ b/src/utils/playControl.js
@@ -2,6 +2,7 @@ import axios from "axios";
 import Hls from "hls.js";
 
 import { getChannelInfo } from "@/apis/radioChannels";
+import { BACKEND_API_URL } from "@/constants/env";
 import { stopWhisperServer } from "@/utils/stopWhisperServer";
 
 const userId = localStorage.getItem("userId");
@@ -37,8 +38,7 @@ export const controlStreamingPlayback = async (
       const { data } = await getChannelInfo(channelId, userId);
       const streamingUrl = data.url;
       if (isAdDetect) {
-        const backendServerURL = import.meta.env.VITE_BACKEND_API_URL;
-        await axios.post(`${backendServerURL}`, {
+        await axios.post(`${BACKEND_API_URL}/whisper`, {
           streamingUrl,
           userId,
           channelId,

--- a/src/utils/playControl.js
+++ b/src/utils/playControl.js
@@ -37,7 +37,8 @@ export const controlStreamingPlayback = async (
       const { data } = await getChannelInfo(channelId, userId);
       const streamingUrl = data.url;
       if (isAdDetect) {
-        await axios.post("http://localhost:3000/whisper", {
+        const backendServerURL = import.meta.env.VITE_BACKEND_API_URL;
+        await axios.post(`${backendServerURL}`, {
           streamingUrl,
           userId,
           channelId,

--- a/src/utils/stopWhisperServer.js
+++ b/src/utils/stopWhisperServer.js
@@ -1,9 +1,10 @@
 import axios from "axios";
 
+import { WHISPER_API_URL } from "@/constants/env";
+
 export const stopWhisperServer = async (userId) => {
   try {
-    const whisperServerURL = import.meta.env.VITE_WHISPER_API_URL;
-    await axios.post(`${whisperServerURL}/stop`, { userId });
+    await axios.post(`${WHISPER_API_URL}/stop`, { userId });
   } catch (error) {
     console.error("❌ Whisper 종료 실패", error);
   }

--- a/src/utils/stopWhisperServer.js
+++ b/src/utils/stopWhisperServer.js
@@ -2,8 +2,8 @@ import axios from "axios";
 
 export const stopWhisperServer = async (userId) => {
   try {
-    // 추후 배포 시 변경
-    await axios.post("http://localhost:5000/stop", { userId });
+    const whisperServerURL = import.meta.env.VITE_WHISPER_API_URL;
+    await axios.post(`${whisperServerURL}/stop`, { userId });
   } catch (error) {
     console.error("❌ Whisper 종료 실패", error);
   }


### PR DESCRIPTION
### ✨ 이슈 번호

- #122 

### 📌 설명

- Whisper 서버와 백엔드 서버 요청에 필요한 환경 변수로 분리를 구현하여 작성한 Pull Request입니다.
- 두 서버의 역할을 분리하여 관리하기 쉽게 구성합니다.

### 📃 작업 사항

- [x] `.env` 추가
  - [x] `.env`에 `VITE_BACKEND_API_URL` 추가 (기존 `VITE_API_URL` 대체)
  - [x] `.env`에 `VITE_WHISPER_API_URL` 추가 (Whisper 서버 전용)
- [x] env 참조 수정
  - [x] 백엔드 관련 요청 코드에서 `VITE_BACKEND_API_URL` 참조하도록 수정
  - [x] Whisper 관련 요청 코드에서 `VITE_WHISPER_API_URL` 참조하도록 수정
  - [x] 기존 `VITE_API_URL` 사용처를 `VITE_BACKEND_API_URL`로 변경
- [x] Backend, Whisper API URL을 상수로 분리하여 환경 변수로 관리

### 💡 참고 사항

- Whisper 서버는 포트 5000번, Express 백엔드는 3000번에서 운영됩니다.
- 향후 도메인 기반으로 운영될 예정입니다.

### 💭 리뷰 사항 반영

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
