### PR TITLE
feat: 광고 감지 시 이동할 채널 선택 API 연동

### DIFF
--- a/src/constants/settingOptions.js
+++ b/src/constants/settingOptions.js
@@ -1,13 +1,13 @@
 export const SETTING_TYPES = {
   AD_DETECT: "isAdDetect",
   RETURN_CHANNEL: "isReturnChannel",
-  AD_REDIRECT_CHANNEL_ID: "adRedirectChannelId",
+  AD_REDIRECT_CHANNEL: "adRedirectChannelId",
 };
 
 export const SETTING_TITLES = {
   [SETTING_TYPES.AD_DETECT]: "광고 감지",
   [SETTING_TYPES.RETURN_CHANNEL]: "기존 채널로 이동",
-  [SETTING_TYPES.AD_REDIRECT_CHANNEL_ID]: "광고 감지 시 이동할 채널",
+  [SETTING_TYPES.AD_REDIRECT_CHANNEL]: "광고 감지 시 이동할 채널",
 };
 
 export const SETTING_EXPLANATIONS = {
@@ -19,7 +19,7 @@ export const SETTING_EXPLANATIONS = {
     "이전 채널의 광고가 종료되면",
     "자동으로 복귀합니다.",
   ],
-  [SETTING_TYPES.AD_REDIRECT_CHANNEL_ID]: [
+  [SETTING_TYPES.AD_REDIRECT_CHANNEL]: [
     "광고가 감지되면 자동으로 전환할 채널을 선택해 주세요.",
     "지정한 채널로 광고 중 자동 이동됩니다.",
   ],

--- a/src/constants/settingOptions.js
+++ b/src/constants/settingOptions.js
@@ -1,11 +1,13 @@
 export const SETTING_TYPES = {
   AD_DETECT: "isAdDetect",
   RETURN_CHANNEL: "isReturnChannel",
+  AD_REDIRECT_CHANNEL_ID: "adRedirectChannelId",
 };
 
 export const SETTING_TITLES = {
   [SETTING_TYPES.AD_DETECT]: "광고 감지",
   [SETTING_TYPES.RETURN_CHANNEL]: "기존 채널로 이동",
+  [SETTING_TYPES.AD_REDIRECT_CHANNEL_ID]: "광고 감지 시 이동할 채널",
 };
 
 export const SETTING_EXPLANATIONS = {
@@ -16,5 +18,9 @@ export const SETTING_EXPLANATIONS = {
   [SETTING_TYPES.RETURN_CHANNEL]: [
     "이전 채널의 광고가 종료되면",
     "자동으로 복귀합니다.",
+  ],
+  [SETTING_TYPES.AD_REDIRECT_CHANNEL_ID]: [
+    "광고가 감지되면 자동으로 전환할 채널을 선택해 주세요.",
+    "지정한 채널로 광고 중 자동 이동됩니다.",
   ],
 };

--- a/src/hooks/useUpdateSetting.jsx
+++ b/src/hooks/useUpdateSetting.jsx
@@ -15,7 +15,7 @@ const useUpdateSetting = (type) => {
 
     const updatedSettings = { ...settings };
 
-    if (type === SETTING_TYPES.AD_REDIRECT_CHANNEL_ID) {
+    if (type === SETTING_TYPES.AD_REDIRECT_CHANNEL) {
       updatedSettings[type] = value;
     } else {
       updatedSettings[type] = !settings[type];

--- a/src/hooks/useUpdateSetting.jsx
+++ b/src/hooks/useUpdateSetting.jsx
@@ -13,18 +13,15 @@ const useUpdateSetting = (type) => {
       return;
     }
 
-    const updatedSettings = { ...settings };
+    const isToggleType = type !== SETTING_TYPES.AD_REDIRECT_CHANNEL;
+    const toggledValue = isToggleType ? !settings[type] : value;
 
-    if (type === SETTING_TYPES.AD_REDIRECT_CHANNEL) {
-      updatedSettings[type] = value;
-    } else {
-      updatedSettings[type] = !settings[type];
-      if (
-        type === SETTING_TYPES.AD_DETECT &&
-        !updatedSettings[SETTING_TYPES.AD_DETECT]
-      ) {
-        updatedSettings[SETTING_TYPES.RETURN_CHANNEL] = false;
-      }
+    const updatedSettings = {
+      [type]: toggledValue,
+    };
+
+    if (type === SETTING_TYPES.AD_DETECT && !toggledValue) {
+      updatedSettings[SETTING_TYPES.RETURN_CHANNEL] = false;
     }
 
     try {

--- a/src/hooks/useUpdateSetting.jsx
+++ b/src/hooks/useUpdateSetting.jsx
@@ -7,19 +7,24 @@ import { useUserStore } from "@/store/useUserStore";
 const useUpdateSetting = (type) => {
   const { settings, setUserSettings } = useUserStore();
 
-  const updateSetting = async () => {
+  const updateSetting = async (value) => {
     const userId = localStorage.getItem("userId");
     if (!userId) {
       return;
     }
 
-    const updatedSettings = {
-      ...settings,
-      [type]: !settings[type],
-    };
+    const updatedSettings = { ...settings };
 
-    if (type === SETTING_TYPES.AD_DETECT && !updatedSettings.isAdDetect) {
-      updatedSettings.isReturnChannel = false;
+    if (type === SETTING_TYPES.AD_REDIRECT_CHANNEL_ID) {
+      updatedSettings[type] = value;
+    } else {
+      updatedSettings[type] = !settings[type];
+      if (
+        type === SETTING_TYPES.AD_DETECT &&
+        !updatedSettings[SETTING_TYPES.AD_DETECT]
+      ) {
+        updatedSettings[SETTING_TYPES.RETURN_CHANNEL] = false;
+      }
     }
 
     try {

--- a/src/hooks/useUserProfile.jsx
+++ b/src/hooks/useUserProfile.jsx
@@ -15,8 +15,9 @@ const useUserProfile = (userId) => {
     const initUserProfile = async () => {
       try {
         const response = await axios.get(`${BACKEND_API_URL}/users/${userId}`);
-        const { isAdDetect, isReturnChannel } = response.data;
-        setUserSettings({ isAdDetect, isReturnChannel });
+        const { isAdDetect, isReturnChannel, adRedirectChannelId } =
+          response.data;
+        setUserSettings({ isAdDetect, isReturnChannel, adRedirectChannelId });
       } catch (error) {
         console.error("fetch user profile failed: ", error);
       }

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -8,9 +8,11 @@ import {
   SETTING_EXPLANATIONS,
 } from "@/constants/settingOptions";
 import useUpdateSetting from "@/hooks/useUpdateSetting";
+import { useChannelStore } from "@/store/useChannelStore";
 import { useUserStore } from "@/store/useUserStore";
 
 const Settings = () => {
+  const channelList = useChannelStore((state) => state.radioChannelList);
   const isAdDetect = useUserStore((state) => state.settings.isAdDetect);
   const adRedirectChannelId = useUserStore(
     (state) => state.settings.adRedirectChannelId
@@ -27,37 +29,9 @@ const Settings = () => {
     updateAdRedirectChannelId(updatedChannelId);
   };
 
-  // TODO: 동적 구현 시 임시 데이터 삭제
-  const adRedirectChannelList = [
-    {
-      id: 0,
-      name: "KBS 1라디오",
-      logoUrl:
-        "https://rpvlwzikmpjsvztgkytl.supabase.co/storage/v1/object/public/radio-logos//KBS1Radio.png",
-      isSelected: true,
-    },
-    {
-      id: 3,
-      name: "KBS 1FM",
-      logoUrl:
-        "https://rpvlwzikmpjsvztgkytl.supabase.co/storage/v1/object/public/radio-logos//KBS1FM.png",
-      isSelected: false,
-    },
-    {
-      id: 5,
-      name: "KBS 한민족방송",
-      logoUrl:
-        "https://rpvlwzikmpjsvztgkytl.supabase.co/storage/v1/object/public/radio-logos//KBSHanminjok.png",
-      isSelected: false,
-    },
-    {
-      id: 10,
-      name: "고릴라디오M",
-      logoUrl:
-        "https://rpvlwzikmpjsvztgkytl.supabase.co/storage/v1/object/public/radio-logos//GOREALRADIO.png",
-      isSelected: false,
-    },
-  ];
+  const adRedirectChannelList = channelList
+    .filter((channel) => !channel.isAdChannel)
+    .map(({ id, name, logoUrl }) => ({ id, name, logoUrl, isSelected: false }));
 
   return (
     <>

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -18,7 +18,7 @@ const Settings = () => {
     (state) => state.settings.adRedirectChannelId
   );
   const updateAdRedirectChannelId = useUpdateSetting(
-    SETTING_TYPES.AD_REDIRECT_CHANNEL_ID
+    SETTING_TYPES.AD_REDIRECT_CHANNEL
   );
 
   const settingTypes = Object.values(SETTING_TYPES);
@@ -40,7 +40,7 @@ const Settings = () => {
         <ul>
           {settingTypes.map(
             (type) =>
-              type !== SETTING_TYPES.AD_REDIRECT_CHANNEL_ID && (
+              type !== SETTING_TYPES.AD_REDIRECT_CHANNEL && (
                 <SettingListItem
                   key={type}
                   type={type}
@@ -54,9 +54,9 @@ const Settings = () => {
       {isAdDetect && (
         <div className="px-4 pt-2">
           <ChannelSection
-            title={SETTING_TITLES[SETTING_TYPES.AD_REDIRECT_CHANNEL_ID]}
+            title={SETTING_TITLES[SETTING_TYPES.AD_REDIRECT_CHANNEL]}
             subTitleList={
-              SETTING_EXPLANATIONS[SETTING_TYPES.AD_REDIRECT_CHANNEL_ID]
+              SETTING_EXPLANATIONS[SETTING_TYPES.AD_REDIRECT_CHANNEL]
             }
             marginTop="mt-2"
             height="h-80"

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -1,5 +1,3 @@
-import { useState } from "react";
-
 import AdRedirectChannelItem from "@/components/AdRedirectChannelItem";
 import ChannelSection from "@/components/ChannelSection";
 import SettingListItem from "@/components/SettingListItem";
@@ -9,19 +7,24 @@ import {
   SETTING_TITLES,
   SETTING_EXPLANATIONS,
 } from "@/constants/settingOptions";
+import useUpdateSetting from "@/hooks/useUpdateSetting";
 import { useUserStore } from "@/store/useUserStore";
 
 const Settings = () => {
-  const [selectedRedirectChannelId, setSelectedRedirectChannelId] =
-    useState(null);
   const isAdDetect = useUserStore((state) => state.settings.isAdDetect);
+  const adRedirectChannelId = useUserStore(
+    (state) => state.settings.adRedirectChannelId
+  );
+  const updateAdRedirectChannelId = useUpdateSetting(
+    SETTING_TYPES.AD_REDIRECT_CHANNEL_ID
+  );
+
   const settingTypes = Object.values(SETTING_TYPES);
 
   const handleSelectRedirectChannel = (channelId) => {
-    setSelectedRedirectChannelId((prevId) =>
-      prevId === channelId ? null : channelId
-    );
-    // TODO: 동적 구현 시 update api 연결
+    const updatedChannelId =
+      adRedirectChannelId === channelId ? null : channelId;
+    updateAdRedirectChannelId(updatedChannelId);
   };
 
   // TODO: 동적 구현 시 임시 데이터 삭제
@@ -61,24 +64,26 @@ const Settings = () => {
       <TabBar />
       <div className="px-4 pt-4">
         <ul>
-          {settingTypes.map((type) => (
-            <SettingListItem
-              key={type}
-              type={type}
-              title={SETTING_TITLES[type]}
-              explanations={SETTING_EXPLANATIONS[type]}
-            />
-          ))}
+          {settingTypes.map(
+            (type) =>
+              type !== SETTING_TYPES.AD_REDIRECT_CHANNEL_ID && (
+                <SettingListItem
+                  key={type}
+                  type={type}
+                  title={SETTING_TITLES[type]}
+                  explanations={SETTING_EXPLANATIONS[type]}
+                />
+              )
+          )}
         </ul>
       </div>
       {isAdDetect && (
         <div className="px-4 pt-2">
           <ChannelSection
-            title="광고 감지 시 이동할 채널"
-            subTitleList={[
-              "광고가 감지되면 자동으로 전환할 채널을 선택해 주세요.",
-              "지정한 채널로 광고 중 자동 이동됩니다.",
-            ]}
+            title={SETTING_TITLES[SETTING_TYPES.AD_REDIRECT_CHANNEL_ID]}
+            subTitleList={
+              SETTING_EXPLANATIONS[SETTING_TYPES.AD_REDIRECT_CHANNEL_ID]
+            }
             marginTop="mt-2"
             height="h-80"
           >
@@ -88,7 +93,7 @@ const Settings = () => {
                 channelId={id}
                 channelName={name}
                 thumbnail={logoUrl}
-                isSelected={selectedRedirectChannelId === id}
+                isSelected={adRedirectChannelId === id}
                 onSelect={handleSelectRedirectChannel}
               />
             ))}

--- a/src/store/useUserStore.js
+++ b/src/store/useUserStore.js
@@ -10,7 +10,13 @@ export const useUserStore = create(
         adRedirectChannelId: null,
       },
 
-      setUserSettings: (updatedSettings) => set({ settings: updatedSettings }),
+      setUserSettings: (updatedSettings) =>
+        set((state) => ({
+          settings: {
+            ...state.settings,
+            ...updatedSettings,
+          },
+        })),
     }),
     {
       name: "user-settings",

--- a/src/store/useUserStore.js
+++ b/src/store/useUserStore.js
@@ -7,10 +7,10 @@ export const useUserStore = create(
       settings: {
         isAdDetect: true,
         isReturnChannel: false,
+        adRedirectChannelId: null,
       },
 
-      setUserSettings: ({ isAdDetect, isReturnChannel }) =>
-        set({ settings: { isAdDetect, isReturnChannel } }),
+      setUserSettings: (updatedSettings) => set({ settings: updatedSettings }),
     }),
     {
       name: "user-settings",


### PR DESCRIPTION
### ✨ 이슈 번호

- #128 

### 📌 설명

- 광고 감지 시 이동할 채널 선택 기능의 API를 연동한 Pull Request입니다.

### 📃 작업 사항

- [x] 광고 감지 시 이동할 채널 선택 API 연동
- [x] 광고 감지 시 이동할 채널 목록 정적 데이터에서 실제 채널 목록 중 isAdChannel값이 false인 채널로 리팩토링

### 💭 리뷰 사항 반영

- [x] 설정을 업데이트 할 때 모든 설정을 가져와 업데이트 하는 방식에서 업데이트하는 설정만 업데이트 하는 방식으로 변경

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
