### PR TITLE
chore: CI/CD 및 PR 빌드 워크플로우 .env.production 로직 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,12 @@ jobs:
         with:
           node-version: 22.11.0
           cache: npm
+
+      - name: Create .env.production file
+        run: |
+          echo "VITE_WHISPER_API_URL=${{ secrets.VITE_WHISPER_API_URL }}" >> .env.production
+          echo "VITE_BACKEND_API_URL=${{ secrets.VITE_BACKEND_API_URL }}" >> .env.production
+
       - run: npm install
       - run: npm run build
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -15,5 +15,11 @@ jobs:
         with:
           node-version: 22.11.0
           cache: npm
+
+      - name: Create .env.production file
+        run: |
+          echo "VITE_WHISPER_API_URL=${{ secrets.VITE_WHISPER_API_URL }}" >> .env.production
+          echo "VITE_BACKEND_API_URL=${{ secrets.VITE_BACKEND_API_URL }}" >> .env.production
+
       - run: npm install
       - run: npm run build


### PR DESCRIPTION
### ✨ 이슈 번호

- #130 

### 📌 설명

- 기존 워크플로우에서는 `.env.production`이 존재하지 않아 `Vite` 환경변수(import.meta.env.VITE_XXX)가 주입되지 않습니다.
- 이를 해결하기 위해 `GitHub Secrets` 기반으로 `.env.production`을 생성하는 로직을 추가합니다.
- 정식 배포용 워크플로우(CI/CD)와 PR 빌드 확인용에 추가하여 작성한 Pull Request입니다.

### 📃 작업 사항

- [x] 정식 배포용 워크플로우(CI/CD)의 `.env.production`
  - [x] `VITE_WHISPER_API_URL` 
  - [x] `VITE_BACKEND_API_URL`
- [x] PR 빌드 확인용의 `.env.production`
  - [x] `VITE_WHISPER_API_URL` 
  - [x] `VITE_BACKEND_API_URL`

### 💭 리뷰 사항 반영

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
