### PR TITLE
feat: 전역 ErrorBoundary 적용 및 ErrorFallback UI 구성

### DIFF
--- a/src/Router.jsx
+++ b/src/Router.jsx
@@ -3,6 +3,8 @@ import { createBrowserRouter } from "react-router-dom";
 import Home from "@/Channel/components/Home";
 import ChannelPlayer from "@/Playback/components/ChannelPlayer";
 import Search from "@/Search/components/Search";
+import { ErrorBoundary } from "@/shared/components/ErrorBoundary";
+import ErrorFallback from "@/shared/components/ErrorFallback";
 import MainLayout from "@/shared/components/MainLayout";
 import NotFound from "@/shared/components/NotFound";
 import Settings from "@/User/components/Settings";
@@ -10,7 +12,14 @@ import Settings from "@/User/components/Settings";
 const router = createBrowserRouter([
   {
     path: "/",
-    element: <MainLayout />,
+    element: (
+      <ErrorBoundary
+        fallback={ErrorFallback}
+        onReset={() => (window.location.href = "/")}
+      >
+        <MainLayout />
+      </ErrorBoundary>
+    ),
     children: [
       { path: "", element: <Home /> },
       { path: "search-result", element: <Search /> },

--- a/src/Router.jsx
+++ b/src/Router.jsx
@@ -3,8 +3,7 @@ import { createBrowserRouter } from "react-router-dom";
 import Home from "@/Channel/components/Home";
 import ChannelPlayer from "@/Playback/components/ChannelPlayer";
 import Search from "@/Search/components/Search";
-import { ErrorBoundary } from "@/shared/components/ErrorBoundary";
-import ErrorFallback from "@/shared/components/ErrorFallback";
+import ErrorBoundaryWrapper from "@/shared/components/ErrorBoundaryWrapper";
 import MainLayout from "@/shared/components/MainLayout";
 import NotFound from "@/shared/components/NotFound";
 import Settings from "@/User/components/Settings";
@@ -13,12 +12,9 @@ const router = createBrowserRouter([
   {
     path: "/",
     element: (
-      <ErrorBoundary
-        fallback={ErrorFallback}
-        onReset={() => (window.location.href = "/")}
-      >
+      <ErrorBoundaryWrapper>
         <MainLayout />
-      </ErrorBoundary>
+      </ErrorBoundaryWrapper>
     ),
     children: [
       { path: "", element: <Home /> },

--- a/src/shared/components/ErrorBoundary.jsx
+++ b/src/shared/components/ErrorBoundary.jsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+
+export class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+    this.captureReject = this.captureReject.bind(this);
+    this.resetError = this.resetError.bind(this);
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  captureReject(e) {
+    e.preventDefault();
+    console.log("dd");
+    this.setState({ hasError: true });
+  }
+
+  componentDidMount() {
+    window.addEventListener("unhandledrejection", this.captureReject);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener("unhandledrejection", this.captureReject);
+  }
+
+  resetError() {
+    this.setState({ hasError: false });
+    this.props.onReset?.();
+  }
+
+  render() {
+    const { fallback: Fallback, children } = this.props;
+
+    if (this.state.hasError) {
+      console.log("ErrorBoundary에서 에러를 감지했습니다.");
+      return <Fallback resetError={this.resetError} />;
+    }
+
+    return children;
+  }
+}

--- a/src/shared/components/ErrorBoundary.jsx
+++ b/src/shared/components/ErrorBoundary.jsx
@@ -14,7 +14,6 @@ export class ErrorBoundary extends React.Component {
 
   captureReject(e) {
     e.preventDefault();
-    console.log("dd");
     this.setState({ hasError: true });
   }
 

--- a/src/shared/components/ErrorBoundary.jsx
+++ b/src/shared/components/ErrorBoundary.jsx
@@ -34,7 +34,6 @@ export class ErrorBoundary extends React.Component {
     const { fallback: Fallback, children } = this.props;
 
     if (this.state.hasError) {
-      console.log("ErrorBoundary에서 에러를 감지했습니다.");
       return <Fallback resetError={this.resetError} />;
     }
 

--- a/src/shared/components/ErrorBoundaryWrapper.jsx
+++ b/src/shared/components/ErrorBoundaryWrapper.jsx
@@ -1,0 +1,16 @@
+import { useNavigate } from "react-router-dom";
+
+import { ErrorBoundary } from "@/shared/components/ErrorBoundary";
+import ErrorFallback from "@/shared/components/ErrorFallback";
+
+const ErrorBoundaryWrapper = ({ children }) => {
+  const navigate = useNavigate();
+
+  return (
+    <ErrorBoundary fallback={ErrorFallback} onReset={() => navigate("/")}>
+      {children}
+    </ErrorBoundary>
+  );
+};
+
+export default ErrorBoundaryWrapper;

--- a/src/shared/components/ErrorFallback.jsx
+++ b/src/shared/components/ErrorFallback.jsx
@@ -1,0 +1,28 @@
+import WarningIcon from "@/assets/svgs/icon-warning-red.svg?react";
+
+const ErrorFallback = ({ resetError }) => {
+  return (
+    <>
+      <div className="flex items-center justify-center">
+        <WarningIcon className="mt-50" />
+      </div>
+      <h1 className="mt-5 flex items-center justify-center text-xl">
+        데이터를 불러오는 중에 오류가 발생했습니다.
+      </h1>
+      <div className="mt-6 text-center text-sm font-medium text-neutral-500">
+        <p>이용에 불편을 드려 죄송합니다.</p>
+      </div>
+      <hr className="mx-auto mt-6 w-[250px] border-neutral-400" />
+      <div className="mt-5 flex justify-center">
+        <button
+          className="flex cursor-pointer flex-col rounded-lg border-1 border-neutral-400 px-5 py-2 font-bold"
+          onClick={resetError}
+        >
+          홈으로 이동
+        </button>
+      </div>
+    </>
+  );
+};
+
+export default ErrorFallback;


### PR DESCRIPTION
### ✨ 이슈 번호

- #142 

### 📌 설명

아래 기능을 구현한 Pull Request 입니다.

* 렌더링 과정 중에서 발생한 예외에 대응하기 위한 전역 ErrorBoundary를 적용합니다. 
* 예외가 발생하면 ErrorFallback이 렌더링되어 사용자에게 예외가 발생했다는 피드백과 홈으로 돌아갈 수 있는 기능을 제공합니다.

### 📃 작업 사항

- [x] ErrorBoundary 컴포넌트 구현
- [x] ErrorFallback 컴포넌트 구현
- [x] ErrorBoundary 및 ErrorFallback 적용

### 💡 참고 사항

* ErrorBoundary는 하위 컴포넌트 트리에서 발생하는 자바스크립트 에러 및 비동기 예외(unhandledrejection)까지 포착합니다.
* ErrorFallback은 예외 발생 시 사용자에게 직관적인 안내 메시지와 홈 이동 버튼을 제공합니다.
* 라우터 적용으로 MainLayout을 ErrorBoundary로 감싸 하위 라우트 전체에 에러 핸들링이 적용됩니다.
* [Error Boundary React 공식 문서](https://ko.react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary)

### 💭 리뷰 사항 반영

- [x] `onReset`의 `window.location.href = "/"` 코드를 `ErrorBoundaryWrapper`라는 컴포넌트로 만들어 `useNavigate` 방식으로 통일

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
