### PR TITLE
refactor: 스토어 네이밍 명확화 및 import 경로 수정

### DIFF
--- a/src/Channel/hooks/useChannelSwitch.jsx
+++ b/src/Channel/hooks/useChannelSwitch.jsx
@@ -4,7 +4,7 @@ import { getRandomNoAdChannel } from "@/Channel/services/radioChannels";
 import { useChannelStore } from "@/Channel/stores/useChannelStore";
 import useControlStreamingSwitch from "@/Playback/hooks/useControlStreamingSwitch";
 import { useVideoElementStore } from "@/shared/stores/useVideoElementStore";
-import { useUserStore } from "@/User/stores/useUserStore";
+import { useUserSettingsStore } from "@/User/stores/useUserSettingsStore";
 
 const useChannelSwitch = () => {
   const videoElement = useVideoElementStore((state) => state.videoElement);
@@ -14,7 +14,7 @@ const useChannelSwitch = () => {
     (state) => state.setIsChannelChanged
   );
   const setPrevChannelId = useChannelStore((state) => state.setPrevChannelId);
-  const adRedirectChannelId = useUserStore(
+  const adRedirectChannelId = useUserSettingsStore(
     (state) => state.settings.adRedirectChannelId
   );
   const controlStreamingSwitch = useControlStreamingSwitch();

--- a/src/Playback/__tests__/Playback.test.jsx
+++ b/src/Playback/__tests__/Playback.test.jsx
@@ -5,7 +5,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import ChannelPlayer from "@/Playback/components/ChannelPlayer";
 import useChannelPlayback from "@/Playback/hooks/useChannelPlayback";
 import useUpdateSetting from "@/User/hooks/useUpdateSetting";
-import { useUserStore } from "@/User/stores/useUserStore";
+import { useUserSettingsStore } from "@/User/stores/useUserSettingsStore";
 
 const mockSelectedChannel = {
   name: "테스트 채널",
@@ -22,8 +22,8 @@ vi.mock("@/Channel/stores/useChannelStore", () => ({
     }),
 }));
 
-vi.mock("@/User/stores/useUserStore", () => ({
-  useUserStore: vi.fn(),
+vi.mock("@/User/stores/useUserSettingsStore", () => ({
+  useUserSettingsStore: vi.fn(),
 }));
 
 vi.mock("@/Playback/hooks/useChannelPlayback", () => ({
@@ -53,7 +53,7 @@ describe("ChannelPlayer", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    useUserStore.mockReturnValue({
+    useUserSettingsStore.mockReturnValue({
       settings: {
         RETURN_CHANNEL: true,
         AD_DETECT: true,

--- a/src/Playback/components/ChannelPlayer.jsx
+++ b/src/Playback/components/ChannelPlayer.jsx
@@ -8,14 +8,14 @@ import ToggleButton from "@/shared/components/ui/ToggleButton";
 import { CHANNEL_MESSAGES } from "@/shared/constants/messages";
 import { SETTING_TITLES, SETTING_TYPES } from "@/User/constants/settingOptions";
 import useUpdateSetting from "@/User/hooks/useUpdateSetting";
-import { useUserStore } from "@/User/stores/useUserStore";
+import { useUserSettingsStore } from "@/User/stores/useUserSettingsStore";
 
 const ChannelPlayer = () => {
   const { selectedChannel, isPlaying, handlePlayPause } = useChannelPlayback(
     PLAYBACK_MODE.FULL
   );
   const isChannelChanged = useChannelStore((state) => state.isChannelChanged);
-  const { settings } = useUserStore();
+  const { settings } = useUserSettingsStore();
 
   const { name, logoUrl } = selectedChannel;
 

--- a/src/Playback/hooks/useChannelPlayback.jsx
+++ b/src/Playback/hooks/useChannelPlayback.jsx
@@ -7,14 +7,14 @@ import { usePlayingStore } from "@/Playback/stores/usePlayingStore";
 import { controlStreamingPlayback } from "@/Playback/utils/playControl";
 import { useVideoElementStore } from "@/shared/stores/useVideoElementStore";
 import { SETTING_TYPES } from "@/User/constants/settingOptions";
-import { useUserStore } from "@/User/stores/useUserStore";
+import { useUserSettingsStore } from "@/User/stores/useUserSettingsStore";
 
 const useChannelPlayback = (mode) => {
   const videoElement = useVideoElementStore((state) => state.videoElement);
   const { selectedChannelId, radioChannelList } = useChannelStore();
   const { playingChannelId, openMiniPlayer } = useMiniPlayerStore();
   const { isPlaying, setIsPlaying } = usePlayingStore();
-  const { settings } = useUserStore();
+  const { settings } = useUserSettingsStore();
 
   const isProcessing = useRef(false);
 

--- a/src/User/__tests__/Settings.test.jsx
+++ b/src/User/__tests__/Settings.test.jsx
@@ -14,7 +14,7 @@ import { useChannelStore } from "@/Channel/stores/useChannelStore";
 import Settings from "@/User/components/Settings";
 import { SETTING_TYPES } from "@/User/constants/settingOptions";
 import useUpdateSetting from "@/User/hooks/useUpdateSetting";
-import { useUserStore } from "@/User/stores/useUserStore";
+import { useUserSettingsStore } from "@/User/stores/useUserSettingsStore";
 
 vi.mock("axios");
 
@@ -25,7 +25,7 @@ describe("UserSetting", () => {
   });
 
   it("광고 감지 설정이 false일 경우, useUpdateSetting을 호출하면 설정을 true로 변경한다", async () => {
-    useUserStore.setState({ settings: { isAdDetect: false } });
+    useUserSettingsStore.setState({ settings: { isAdDetect: false } });
 
     const { result } = renderHook(() =>
       useUpdateSetting(SETTING_TYPES.AD_DETECT)
@@ -35,11 +35,11 @@ describe("UserSetting", () => {
       await result.current();
     });
 
-    expect(useUserStore.getState().settings.isAdDetect).toBe(true);
+    expect(useUserSettingsStore.getState().settings.isAdDetect).toBe(true);
   });
 
   it("이전 채널 설정이 false일 경우, useUpdateSetting을 호출하면 설정을 true로 변경한다", async () => {
-    useUserStore.setState({ settings: { isReturnChannel: false } });
+    useUserSettingsStore.setState({ settings: { isReturnChannel: false } });
 
     const { result } = renderHook(() =>
       useUpdateSetting(SETTING_TYPES.RETURN_CHANNEL)
@@ -49,11 +49,11 @@ describe("UserSetting", () => {
       await result.current();
     });
 
-    expect(useUserStore.getState().settings.isReturnChannel).toBe(true);
+    expect(useUserSettingsStore.getState().settings.isReturnChannel).toBe(true);
   });
 
   it("광고 감지가 true일 때 광고 없는 채널 선택 UI를 표시한다", () => {
-    useUserStore.setState({ settings: { isAdDetect: true } });
+    useUserSettingsStore.setState({ settings: { isAdDetect: true } });
 
     render(
       <MemoryRouter>
@@ -65,7 +65,7 @@ describe("UserSetting", () => {
   });
 
   it("광고 감지가 false일 때 광고 없는 채널 선택 UI를 표시하지 않는다", () => {
-    useUserStore.setState({ settings: { isAdDetect: false } });
+    useUserSettingsStore.setState({ settings: { isAdDetect: false } });
 
     render(
       <MemoryRouter>
@@ -77,7 +77,7 @@ describe("UserSetting", () => {
   });
 
   it("광고 없는 채널 중 하나만 선택된 상태로 표시한다", () => {
-    useUserStore.setState({
+    useUserSettingsStore.setState({
       settings: {
         isAdDetect: true,
         adRedirectChannelId: 2,

--- a/src/User/components/SettingListItem.jsx
+++ b/src/User/components/SettingListItem.jsx
@@ -1,10 +1,10 @@
 import ToggleButton from "@/shared/components/ui/ToggleButton";
 import { SETTING_TYPES } from "@/User/constants/settingOptions";
 import useUpdateSetting from "@/User/hooks/useUpdateSetting";
-import { useUserStore } from "@/User/stores/useUserStore";
+import { useUserSettingsStore } from "@/User/stores/useUserSettingsStore";
 
 const SettingListItem = ({ type, title, explanations }) => {
-  const { settings } = useUserStore();
+  const { settings } = useUserSettingsStore();
   const updateSetting = useUpdateSetting(type);
 
   const handleToggle = () => {

--- a/src/User/components/Settings.jsx
+++ b/src/User/components/Settings.jsx
@@ -9,12 +9,12 @@ import {
   SETTING_EXPLANATIONS,
 } from "@/User/constants/settingOptions";
 import useUpdateSetting from "@/User/hooks/useUpdateSetting";
-import { useUserStore } from "@/User/stores/useUserStore";
+import { useUserSettingsStore } from "@/User/stores/useUserSettingsStore";
 
 const Settings = () => {
   const channelList = useChannelStore((state) => state.radioChannelList);
-  const isAdDetect = useUserStore((state) => state.settings.isAdDetect);
-  const adRedirectChannelId = useUserStore(
+  const isAdDetect = useUserSettingsStore((state) => state.settings.isAdDetect);
+  const adRedirectChannelId = useUserSettingsStore(
     (state) => state.settings.adRedirectChannelId
   );
   const updateAdRedirectChannelId = useUpdateSetting(

--- a/src/User/hooks/useUpdateSetting.jsx
+++ b/src/User/hooks/useUpdateSetting.jsx
@@ -2,10 +2,10 @@ import axios from "axios";
 
 import { BACKEND_API_URL } from "@/shared/constants/env";
 import { SETTING_TYPES } from "@/User/constants/settingOptions";
-import { useUserStore } from "@/User/stores/useUserStore";
+import { useUserSettingsStore } from "@/User/stores/useUserSettingsStore";
 
 const useUpdateSetting = (type) => {
-  const { settings, setUserSettings } = useUserStore();
+  const { settings, setUserSettings } = useUserSettingsStore();
 
   const updateSetting = async (value) => {
     const userId = localStorage.getItem("userId");

--- a/src/User/hooks/useUserProfile.jsx
+++ b/src/User/hooks/useUserProfile.jsx
@@ -2,10 +2,10 @@ import axios from "axios";
 import { useEffect } from "react";
 
 import { BACKEND_API_URL } from "@/shared/constants/env";
-import { useUserStore } from "@/User/stores/useUserStore";
+import { useUserSettingsStore } from "@/User/stores/useUserSettingsStore";
 
 const useUserProfile = (userId) => {
-  const { setUserSettings } = useUserStore();
+  const { setUserSettings } = useUserSettingsStore();
 
   useEffect(() => {
     if (!userId) {

--- a/src/User/stores/useUserSettingsStore.js
+++ b/src/User/stores/useUserSettingsStore.js
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
-export const useUserStore = create(
+export const useUserSettingsStore = create(
   persist(
     (set) => ({
       settings: {
@@ -19,7 +19,7 @@ export const useUserStore = create(
         })),
     }),
     {
-      name: "user-settings",
+      name: "user-settings-storage",
     }
   )
 );


### PR DESCRIPTION
### ✨ 이슈 번호 

- #152 

### 📌 설명 

- `useUserStore`에서는 유저 설정값(`settings`)만 관리하고 있습니다.
- 네이밍상 `useUserStore`라는 이름은 유저 전체 정보까지 포함할 것 같은 느낌을 줄 수 있어서, 명확한 의미 전달을 위해 `useUserSettingsStorage`라는 네이밍으로 변경하였습니다.
- 스토어 네이밍 변경에 맞추어 persist name 또한 `user-settings-storage`로 수정하고, 스토어를 `import`하고 있는 컴포넌트, 훅 등 전역 `import` 경로도 함께 업데이트한 Pull Request입니다.

### 📃 작업 사항

- [x] `useUserStore` → `useUserSettingsStorage` 로 네이밍 변경
- [x] persist name 수정: `user-settings` → `user-settings-storage`
- [x] `export`명 변경 및 `import` 경로 전역 수정


### 💭 리뷰 사항 반영 


### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
