### PR TITLE
refactor: 반복적인 try-catch 블록 공통 처리

### DIFF
--- a/src/AdReport/hooks/useSubmitAdReport.jsx
+++ b/src/AdReport/hooks/useSubmitAdReport.jsx
@@ -1,17 +1,12 @@
 import { createAdReport } from "@/AdReport/services/reports";
+import { handleAsyncError } from "@/shared/utils/handleAsyncError";
 
 const useSubmitAdReport = () => {
   const reportAd = async ({ userId, isAd, detectedAdPhrase, channelId }) => {
-    try {
-      return await createAdReport({
-        userId,
-        isAd,
-        detectedAdPhrase,
-        channelId,
-      });
-    } catch (error) {
-      console.error("fetch ad report failed:", error);
-    }
+    return handleAsyncError(
+      () => createAdReport({ userId, isAd, detectedAdPhrase, channelId }),
+      "Failed to create ad report:"
+    );
   };
 
   return reportAd;

--- a/src/Channel/hooks/useChannelSwitch.jsx
+++ b/src/Channel/hooks/useChannelSwitch.jsx
@@ -4,6 +4,7 @@ import { getRandomNoAdChannel } from "@/Channel/services/radioChannels";
 import { useChannelStore } from "@/Channel/stores/useChannelStore";
 import useControlStreamingSwitch from "@/Playback/hooks/useControlStreamingSwitch";
 import { useVideoElementStore } from "@/shared/stores/useVideoElementStore";
+import { handleAsyncError } from "@/shared/utils/handleAsyncError";
 import { useUserSettingsStore } from "@/User/stores/useUserSettingsStore";
 
 const useChannelSwitch = () => {
@@ -21,10 +22,11 @@ const useChannelSwitch = () => {
 
   const handleChannelSwitch = useCallback(
     async (isAd) => {
-      try {
+      await handleAsyncError(async () => {
         let channelId = 0;
+
         if (isAd) {
-          try {
+          await handleAsyncError(async () => {
             if (adRedirectChannelId === null) {
               const { data } = await getRandomNoAdChannel();
               channelId = data.id;
@@ -34,9 +36,7 @@ const useChannelSwitch = () => {
 
             setIsChannelChanged(true);
             setPrevChannelId(selectedChannelId);
-          } catch (error) {
-            console.error("fetch randomNoAdchannel failed", error);
-          }
+          }, "Failed to fetch random no-ad channel:");
         } else {
           if (prevChannelId === null || prevChannelId === undefined) {
             return;
@@ -48,9 +48,7 @@ const useChannelSwitch = () => {
         }
 
         await controlStreamingSwitch(videoElement, channelId);
-      } catch (error) {
-        console.error("switch failed: ", error);
-      }
+      }, "Failed to switch channel:");
     },
     [
       prevChannelId,

--- a/src/Channel/hooks/useChannels.jsx
+++ b/src/Channel/hooks/useChannels.jsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 
 import { getRadioChannels } from "@/Channel/services/radioChannels";
 import { useChannelStore } from "@/Channel/stores/useChannelStore";
+import { handleAsyncError } from "@/shared/utils/handleAsyncError";
 
 const useChannels = () => {
   const { radioChannelList, setRadioChannelList } = useChannelStore();
@@ -11,13 +12,11 @@ const useChannels = () => {
       return;
     }
 
-    const initChannels = async () => {
-      try {
+    const initChannels = () => {
+      handleAsyncError(async () => {
         const data = await getRadioChannels();
         setRadioChannelList(data);
-      } catch (error) {
-        console.error("fetch radioChannels failed: ", error);
-      }
+      }, "Failed to fetch radio channels:");
     };
     initChannels();
   }, [radioChannelList, setRadioChannelList]);

--- a/src/Channel/hooks/useControlStreamingSwitch.jsx
+++ b/src/Channel/hooks/useControlStreamingSwitch.jsx
@@ -2,6 +2,7 @@ import { getChannelInfo } from "@/Channel/services/radioChannels";
 import { useChannelStore } from "@/Channel/stores/useChannelStore";
 import { useMiniPlayerStore } from "@/Playback/stores/useMiniPlayerStore";
 import { startStreamingPlay } from "@/Playback/utils/playControl";
+import { handleAsyncError } from "@/shared/utils/handleAsyncError";
 
 const useControlStreamingSwitch = () => {
   const { setSelectedChannelId } = useChannelStore();
@@ -14,13 +15,12 @@ const useControlStreamingSwitch = () => {
 
   const controlStreamingSwitch = async (videoElement, channelId) => {
     const userId = localStorage.getItem("userId");
-    try {
+
+    return handleAsyncError(async () => {
       const { data } = await getChannelInfo(channelId, userId);
       startStreamingPlay(videoElement, data.url);
       updateChannelState(channelId);
-    } catch (error) {
-      console.error("fetch channelInfo failed", error);
-    }
+    }, "Failed to fetch channel info:");
   };
 
   return controlStreamingSwitch;

--- a/src/Channel/hooks/useInterestChannels.jsx
+++ b/src/Channel/hooks/useInterestChannels.jsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 
 import { getInterestChannels } from "@/Channel/services/interestChannels";
 import { useChannelStore } from "@/Channel/stores/useChannelStore";
+import { handleAsyncError } from "@/shared/utils/handleAsyncError";
 
 const useInterestChannels = (userId) => {
   const setInterestChannelIds = useChannelStore(
@@ -14,13 +15,11 @@ const useInterestChannels = (userId) => {
     }
 
     const getInterestIds = async () => {
-      try {
+      await handleAsyncError(async () => {
         const data = await getInterestChannels(userId);
         const ids = data.map((item) => item.channelId);
         setInterestChannelIds(ids);
-      } catch (error) {
-        console.error("fetch interestIds failed: ", error);
-      }
+      }, "Failed to fetch interest channel IDs:");
     };
     getInterestIds();
   }, [userId, setInterestChannelIds]);

--- a/src/Channel/hooks/useToggleFavorite.jsx
+++ b/src/Channel/hooks/useToggleFavorite.jsx
@@ -3,6 +3,7 @@ import {
   deleteInterestChannel,
 } from "@/Channel/services/interestChannels";
 import { useChannelStore } from "@/Channel/stores/useChannelStore";
+import { handleAsyncError } from "@/shared/utils/handleAsyncError";
 import useUserId from "@/User/hooks/useUserId";
 
 const useToggleFavorite = () => {
@@ -16,18 +17,18 @@ const useToggleFavorite = () => {
 
     const isFavorite = interestChannelIds.includes(channelId);
 
-    try {
-      if (isFavorite) {
+    if (isFavorite) {
+      await handleAsyncError(async () => {
         await deleteInterestChannel(userId, channelId);
         setInterestChannelIds(
           interestChannelIds.filter((id) => id !== channelId)
         );
-      } else {
+      }, "Failed to delete interest channel:");
+    } else {
+      await handleAsyncError(async () => {
         await createInterestChannel(userId, channelId);
         setInterestChannelIds([...interestChannelIds, channelId]);
-      }
-    } catch (error) {
-      console.error("fetch toggleFavorite failed: ", error);
+      }, "Failed to create interest channel:");
     }
   };
 

--- a/src/Channel/services/radioChannels.js
+++ b/src/Channel/services/radioChannels.js
@@ -7,7 +7,7 @@ export const getRadioChannels = async () => {
 };
 
 export const getChannelInfo = async (channelId, userId) => {
-  await axiosInstance.get(`/radio-channels/${channelId}`, {
+  return await axiosInstance.get(`/radio-channels/${channelId}`, {
     params: { userId },
   });
 };

--- a/src/Channel/utils/dragHandlers.js
+++ b/src/Channel/utils/dragHandlers.js
@@ -1,6 +1,7 @@
 import { arrayMove } from "@dnd-kit/sortable";
 
 import { updateInterestChannels } from "@/Channel/services/interestChannels";
+import { handleAsyncError } from "@/shared/utils/handleAsyncError";
 
 export const handleChannelDragEnd = async (
   event,
@@ -28,9 +29,9 @@ export const handleChannelDragEnd = async (
   setFavoriteChannelList(newList);
 
   const newOrder = newList.map((channel) => channel.id);
-  try {
-    await updateInterestChannels(userId, newOrder);
-  } catch (error) {
-    console.error("fetch updateFavorite failed: ", error);
-  }
+
+  await handleAsyncError(
+    () => updateInterestChannels(userId, newOrder),
+    "Failed to update interest channel:"
+  );
 };

--- a/src/Playback/hooks/useControlStreamingSwitch.jsx
+++ b/src/Playback/hooks/useControlStreamingSwitch.jsx
@@ -2,6 +2,7 @@ import { getChannelInfo } from "@/Channel/services/radioChannels";
 import { useChannelStore } from "@/Channel/stores/useChannelStore";
 import { useMiniPlayerStore } from "@/Playback/stores/useMiniPlayerStore";
 import { startStreamingPlay } from "@/Playback/utils/playControl";
+import { handleAsyncError } from "@/shared/utils/handleAsyncError";
 
 const useControlStreamingSwitch = () => {
   const { setSelectedChannelId } = useChannelStore();
@@ -14,13 +15,12 @@ const useControlStreamingSwitch = () => {
 
   const controlStreamingSwitch = async (videoElement, channelId) => {
     const userId = localStorage.getItem("userId");
-    try {
+
+    await handleAsyncError(async () => {
       const { data } = await getChannelInfo(channelId, userId);
       startStreamingPlay(videoElement, data.url);
       updateChannelState(channelId);
-    } catch (error) {
-      console.error("fetch channelInfo failed", error);
-    }
+    }, "Failed to fetch channel info:");
   };
 
   return controlStreamingSwitch;

--- a/src/User/hooks/useUpdateSetting.jsx
+++ b/src/User/hooks/useUpdateSetting.jsx
@@ -1,3 +1,4 @@
+import { handleAsyncError } from "@/shared/utils/handleAsyncError";
 import { SETTING_TYPES } from "@/User/constants/settingOptions";
 import { updateUserSettings } from "@/User/services/userSettings";
 import { useUserSettingsStore } from "@/User/stores/useUserSettingsStore";
@@ -22,12 +23,10 @@ const useUpdateSetting = (type) => {
       updatedSettings[SETTING_TYPES.RETURN_CHANNEL] = false;
     }
 
-    try {
+    await handleAsyncError(async () => {
       await updateUserSettings(userId, updatedSettings);
       setUserSettings(updatedSettings);
-    } catch (error) {
-      console.error("setting change failed", error);
-    }
+    }, "Failed to update user setting:");
   };
 
   return updateSetting;

--- a/src/User/hooks/useUserId.jsx
+++ b/src/User/hooks/useUserId.jsx
@@ -1,21 +1,20 @@
 import { useEffect, useState } from "react";
 
+import { handleAsyncError } from "@/shared/utils/handleAsyncError";
 import { createUser } from "@/User/services/users";
 
 const useUserId = () => {
   const [userId, setUserId] = useState(null);
 
   useEffect(() => {
-    const fetchUserId = async () => {
+    const fetchUserId = () => {
       const storedId = localStorage.getItem("userId");
 
       if (storedId === null) {
-        try {
+        return handleAsyncError(async () => {
           const userId = await createUser();
           localStorage.setItem("userId", userId);
-        } catch (error) {
-          console.error("fetch userId failed: ", error);
-        }
+        }, "Failed to create user:");
       } else {
         setUserId(storedId);
       }

--- a/src/User/hooks/useUserProfile.jsx
+++ b/src/User/hooks/useUserProfile.jsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 
+import { handleAsyncError } from "@/shared/utils/handleAsyncError";
 import { getUserInfo } from "@/User/services/users";
 import { useUserSettingsStore } from "@/User/stores/useUserSettingsStore";
 
@@ -12,13 +13,11 @@ const useUserProfile = (userId) => {
     }
 
     const initUserProfile = async () => {
-      try {
+      await handleAsyncError(async () => {
         const data = await getUserInfo(userId);
         const { isAdDetect, isReturnChannel, adRedirectChannelId } = data;
         setUserSettings({ isAdDetect, isReturnChannel, adRedirectChannelId });
-      } catch (error) {
-        console.error("fetch user profile failed: ", error);
-      }
+      }, "Failed to fetch user profile:");
     };
     initUserProfile();
   }, [userId, setUserSettings]);

--- a/src/shared/utils/handleAsyncError.js
+++ b/src/shared/utils/handleAsyncError.js
@@ -1,0 +1,10 @@
+export const handleAsyncError = async (
+  fn,
+  errorMessage = "An error occurred"
+) => {
+  try {
+    return await fn();
+  } catch (error) {
+    console.error(errorMessage, error);
+  }
+};


### PR DESCRIPTION
### ✨ 이슈 번호

- #160

### 📌 설명

- 현재 코드 곳곳에서 `try-catch` 블록이 반복적으로 사용되고 있으며, 주로 API 호출 시 예외 처리를 위해 동일한 패턴이 반복되고 있습니다.
- 이를 공통 유틸 함수로 추출하여 코드 중복을 제거하고 가독성을 높입니다.
- 기존 `try-catch` 사용하는 부분 교체하여 작성한 Pull Request입니다.

### 📃 작업 사항

- [x] 공통 유틸 함수 작성(`handleAsyncError`)
- [x] 기존 `try-catch` 사용하는 부분 교체

### 💭 리뷰 사항 반영

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
