### PR TITLE
refactor: Zustand 상태 업데이트 네이밍 및 함수 작성 스타일 통일

### DIFF
--- a/src/Channel/hooks/useChannelSwitch.jsx
+++ b/src/Channel/hooks/useChannelSwitch.jsx
@@ -15,7 +15,7 @@ const useChannelSwitch = () => {
   );
   const setPrevChannelId = useChannelStore((state) => state.setPrevChannelId);
   const adRedirectChannelId = useUserSettingsStore(
-    (state) => state.settings.adRedirectChannelId
+    (state) => state.userSettings.adRedirectChannelId
   );
   const controlStreamingSwitch = useControlStreamingSwitch();
 

--- a/src/Channel/stores/useChannelStore.js
+++ b/src/Channel/stores/useChannelStore.js
@@ -12,12 +12,10 @@ export const useChannelStore = create(
 
       setInterestChannelIds: (interestChannelIds) =>
         set({ interestChannelIds }),
-      setIsChannelChanged: (isChanged) => set({ isChannelChanged: isChanged }),
-      setPrevChannelId: (channelId) => set({ prevChannelId: channelId }),
-      setRadioChannelList: (channelList) =>
-        set({ radioChannelList: channelList }),
-      setSelectedChannelId: (channelId) =>
-        set({ selectedChannelId: channelId }),
+      setIsChannelChanged: (isChannelChanged) => set({ isChannelChanged }),
+      setPrevChannelId: (prevChannelId) => set({ prevChannelId }),
+      setRadioChannelList: (radioChannelList) => set({ radioChannelList }),
+      setSelectedChannelId: (selectedChannelId) => set({ selectedChannelId }),
     }),
     {
       name: "channel-storage",

--- a/src/Playback/__tests__/Playback.test.jsx
+++ b/src/Playback/__tests__/Playback.test.jsx
@@ -54,7 +54,7 @@ describe("ChannelPlayer", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     useUserSettingsStore.mockReturnValue({
-      settings: {
+      userSettings: {
         RETURN_CHANNEL: true,
         AD_DETECT: true,
       },

--- a/src/Playback/components/ChannelPlayer.jsx
+++ b/src/Playback/components/ChannelPlayer.jsx
@@ -15,7 +15,7 @@ const ChannelPlayer = () => {
     PLAYBACK_MODE.FULL
   );
   const isChannelChanged = useChannelStore((state) => state.isChannelChanged);
-  const { settings } = useUserSettingsStore();
+  const { userSettings } = useUserSettingsStore();
 
   const { name, logoUrl } = selectedChannel;
 
@@ -46,7 +46,7 @@ const ChannelPlayer = () => {
           <ToggleButton
             data-testid="toggle-button"
             size="s"
-            checked={settings[settingType]}
+            checked={userSettings[settingType]}
             onToggle={handleToggle}
           />
         </div>

--- a/src/Playback/hooks/useChannelPlayback.jsx
+++ b/src/Playback/hooks/useChannelPlayback.jsx
@@ -14,11 +14,11 @@ const useChannelPlayback = (mode) => {
   const { selectedChannelId, radioChannelList } = useChannelStore();
   const { playingChannelId, openMiniPlayer } = useMiniPlayerStore();
   const { isPlaying, setIsPlaying } = usePlayingStore();
-  const { settings } = useUserSettingsStore();
+  const { userSettings } = useUserSettingsStore();
 
   const isProcessing = useRef(false);
 
-  const isAdDetect = settings[SETTING_TYPES.AD_DETECT];
+  const isAdDetect = userSettings[SETTING_TYPES.AD_DETECT];
 
   const isMiniMode = mode === PLAYBACK_MODE.MINI;
   const targetChannelId = isMiniMode ? playingChannelId : selectedChannelId;

--- a/src/Playback/stores/useMiniPlayerStore.js
+++ b/src/Playback/stores/useMiniPlayerStore.js
@@ -4,8 +4,8 @@ export const useMiniPlayerStore = create((set) => ({
   isVisible: false,
   playingChannelId: null,
 
-  setPlayingChannelId: (channelId) => set({ playingChannelId: channelId }),
-  openMiniPlayer: (channelId) =>
-    set({ isVisible: true, playingChannelId: channelId }),
+  setPlayingChannelId: (playingChannelId) => set({ playingChannelId }),
+  openMiniPlayer: (playingChannelId) =>
+    set({ isVisible: true, playingChannelId }),
   closeMiniPlayer: () => set({ isVisible: false, playingChannelId: null }),
 }));

--- a/src/Playback/stores/usePlayingStore.js
+++ b/src/Playback/stores/usePlayingStore.js
@@ -3,8 +3,8 @@ import { create } from "zustand";
 export const usePlayingStore = create((set) => ({
   isPlaying: false,
 
-  setIsPlaying: (updater) =>
-    typeof updater === "function"
-      ? set((state) => ({ isPlaying: updater(state.isPlaying) }))
-      : set({ isPlaying: updater }),
+  setIsPlaying: (isPlaying) =>
+    typeof isPlaying === "function"
+      ? set((state) => ({ isPlaying: isPlaying(state.isPlaying) }))
+      : set({ isPlaying }),
 }));

--- a/src/Search/stores/useSearchStore.js
+++ b/src/Search/stores/useSearchStore.js
@@ -3,5 +3,5 @@ import { create } from "zustand";
 export const useSearchStore = create((set) => ({
   keyword: "",
 
-  setKeyword: (value) => set({ keyword: value }),
+  setKeyword: (keyword) => set({ keyword }),
 }));

--- a/src/User/__tests__/Settings.test.jsx
+++ b/src/User/__tests__/Settings.test.jsx
@@ -25,7 +25,7 @@ describe("UserSetting", () => {
   });
 
   it("광고 감지 설정이 false일 경우, useUpdateSetting을 호출하면 설정을 true로 변경한다", async () => {
-    useUserSettingsStore.setState({ settings: { isAdDetect: false } });
+    useUserSettingsStore.setState({ userSettings: { isAdDetect: false } });
 
     const { result } = renderHook(() =>
       useUpdateSetting(SETTING_TYPES.AD_DETECT)
@@ -35,11 +35,11 @@ describe("UserSetting", () => {
       await result.current();
     });
 
-    expect(useUserSettingsStore.getState().settings.isAdDetect).toBe(true);
+    expect(useUserSettingsStore.getState().userSettings.isAdDetect).toBe(true);
   });
 
   it("이전 채널 설정이 false일 경우, useUpdateSetting을 호출하면 설정을 true로 변경한다", async () => {
-    useUserSettingsStore.setState({ settings: { isReturnChannel: false } });
+    useUserSettingsStore.setState({ userSettings: { isReturnChannel: false } });
 
     const { result } = renderHook(() =>
       useUpdateSetting(SETTING_TYPES.RETURN_CHANNEL)
@@ -49,11 +49,13 @@ describe("UserSetting", () => {
       await result.current();
     });
 
-    expect(useUserSettingsStore.getState().settings.isReturnChannel).toBe(true);
+    expect(useUserSettingsStore.getState().userSettings.isReturnChannel).toBe(
+      true
+    );
   });
 
   it("광고 감지가 true일 때 광고 없는 채널 선택 UI를 표시한다", () => {
-    useUserSettingsStore.setState({ settings: { isAdDetect: true } });
+    useUserSettingsStore.setState({ userSettings: { isAdDetect: true } });
 
     render(
       <MemoryRouter>
@@ -65,7 +67,7 @@ describe("UserSetting", () => {
   });
 
   it("광고 감지가 false일 때 광고 없는 채널 선택 UI를 표시하지 않는다", () => {
-    useUserSettingsStore.setState({ settings: { isAdDetect: false } });
+    useUserSettingsStore.setState({ userSettings: { isAdDetect: false } });
 
     render(
       <MemoryRouter>
@@ -78,7 +80,7 @@ describe("UserSetting", () => {
 
   it("광고 없는 채널 중 하나만 선택된 상태로 표시한다", () => {
     useUserSettingsStore.setState({
-      settings: {
+      userSettings: {
         isAdDetect: true,
         adRedirectChannelId: 2,
       },

--- a/src/User/components/SettingListItem.jsx
+++ b/src/User/components/SettingListItem.jsx
@@ -4,7 +4,7 @@ import useUpdateSetting from "@/User/hooks/useUpdateSetting";
 import { useUserSettingsStore } from "@/User/stores/useUserSettingsStore";
 
 const SettingListItem = ({ type, title, explanations }) => {
-  const { settings } = useUserSettingsStore();
+  const { userSettings } = useUserSettingsStore();
   const updateSetting = useUpdateSetting(type);
 
   const handleToggle = () => {
@@ -29,10 +29,10 @@ const SettingListItem = ({ type, title, explanations }) => {
       </div>
       <div className="my-auto ml-auto">
         <ToggleButton
-          checked={settings[type]}
+          checked={userSettings[type]}
           onToggle={handleToggle}
           disabled={
-            type === SETTING_TYPES.RETURN_CHANNEL && !settings.isAdDetect
+            type === SETTING_TYPES.RETURN_CHANNEL && !userSettings.isAdDetect
           }
         />
       </div>

--- a/src/User/components/Settings.jsx
+++ b/src/User/components/Settings.jsx
@@ -13,9 +13,11 @@ import { useUserSettingsStore } from "@/User/stores/useUserSettingsStore";
 
 const Settings = () => {
   const channelList = useChannelStore((state) => state.radioChannelList);
-  const isAdDetect = useUserSettingsStore((state) => state.settings.isAdDetect);
+  const isAdDetect = useUserSettingsStore(
+    (state) => state.userSettings.isAdDetect
+  );
   const adRedirectChannelId = useUserSettingsStore(
-    (state) => state.settings.adRedirectChannelId
+    (state) => state.userSettings.adRedirectChannelId
   );
   const updateAdRedirectChannelId = useUpdateSetting(
     SETTING_TYPES.AD_REDIRECT_CHANNEL

--- a/src/User/hooks/useUpdateSetting.jsx
+++ b/src/User/hooks/useUpdateSetting.jsx
@@ -3,7 +3,7 @@ import { updateUserSettings } from "@/User/services/userSettings";
 import { useUserSettingsStore } from "@/User/stores/useUserSettingsStore";
 
 const useUpdateSetting = (type) => {
-  const { settings, setSettings } = useUserSettingsStore();
+  const { userSettings, setUserSettings } = useUserSettingsStore();
 
   const updateSetting = async (value) => {
     const userId = localStorage.getItem("userId");
@@ -12,7 +12,7 @@ const useUpdateSetting = (type) => {
     }
 
     const isToggleType = type !== SETTING_TYPES.AD_REDIRECT_CHANNEL;
-    const toggledValue = isToggleType ? !settings[type] : value;
+    const toggledValue = isToggleType ? !userSettings[type] : value;
 
     const updatedSettings = {
       [type]: toggledValue,
@@ -24,7 +24,7 @@ const useUpdateSetting = (type) => {
 
     try {
       await updateUserSettings(userId, updatedSettings);
-      setSettings(updatedSettings);
+      setUserSettings(updatedSettings);
     } catch (error) {
       console.error("setting change failed", error);
     }

--- a/src/User/hooks/useUpdateSetting.jsx
+++ b/src/User/hooks/useUpdateSetting.jsx
@@ -3,7 +3,7 @@ import { updateUserSettings } from "@/User/services/userSettings";
 import { useUserSettingsStore } from "@/User/stores/useUserSettingsStore";
 
 const useUpdateSetting = (type) => {
-  const { settings, setUserSettings } = useUserSettingsStore();
+  const { settings, setSettings } = useUserSettingsStore();
 
   const updateSetting = async (value) => {
     const userId = localStorage.getItem("userId");
@@ -24,7 +24,7 @@ const useUpdateSetting = (type) => {
 
     try {
       await updateUserSettings(userId, updatedSettings);
-      setUserSettings(updatedSettings);
+      setSettings(updatedSettings);
     } catch (error) {
       console.error("setting change failed", error);
     }

--- a/src/User/hooks/useUserProfile.jsx
+++ b/src/User/hooks/useUserProfile.jsx
@@ -4,7 +4,7 @@ import { getUserInfo } from "@/User/services/users";
 import { useUserSettingsStore } from "@/User/stores/useUserSettingsStore";
 
 const useUserProfile = (userId) => {
-  const { setUserSettings } = useUserSettingsStore();
+  const { setSettings } = useUserSettingsStore();
 
   useEffect(() => {
     if (!userId) {
@@ -15,13 +15,13 @@ const useUserProfile = (userId) => {
       try {
         const data = await getUserInfo(userId);
         const { isAdDetect, isReturnChannel, adRedirectChannelId } = data;
-        setUserSettings({ isAdDetect, isReturnChannel, adRedirectChannelId });
+        setSettings({ isAdDetect, isReturnChannel, adRedirectChannelId });
       } catch (error) {
         console.error("fetch user profile failed: ", error);
       }
     };
     initUserProfile();
-  }, [userId, setUserSettings]);
+  }, [userId, setSettings]);
 };
 
 export default useUserProfile;

--- a/src/User/hooks/useUserProfile.jsx
+++ b/src/User/hooks/useUserProfile.jsx
@@ -4,7 +4,7 @@ import { getUserInfo } from "@/User/services/users";
 import { useUserSettingsStore } from "@/User/stores/useUserSettingsStore";
 
 const useUserProfile = (userId) => {
-  const { setSettings } = useUserSettingsStore();
+  const { setUserSettings } = useUserSettingsStore();
 
   useEffect(() => {
     if (!userId) {
@@ -15,13 +15,13 @@ const useUserProfile = (userId) => {
       try {
         const data = await getUserInfo(userId);
         const { isAdDetect, isReturnChannel, adRedirectChannelId } = data;
-        setSettings({ isAdDetect, isReturnChannel, adRedirectChannelId });
+        setUserSettings({ isAdDetect, isReturnChannel, adRedirectChannelId });
       } catch (error) {
         console.error("fetch user profile failed: ", error);
       }
     };
     initUserProfile();
-  }, [userId, setSettings]);
+  }, [userId, setUserSettings]);
 };
 
 export default useUserProfile;

--- a/src/User/stores/useUserSettingsStore.js
+++ b/src/User/stores/useUserSettingsStore.js
@@ -10,11 +10,11 @@ export const useUserSettingsStore = create(
         adRedirectChannelId: null,
       },
 
-      setUserSettings: (updatedSettings) =>
+      setSettings: (settings) =>
         set((state) => ({
           settings: {
             ...state.settings,
-            ...updatedSettings,
+            ...settings,
           },
         })),
     }),

--- a/src/User/stores/useUserSettingsStore.js
+++ b/src/User/stores/useUserSettingsStore.js
@@ -4,17 +4,17 @@ import { persist } from "zustand/middleware";
 export const useUserSettingsStore = create(
   persist(
     (set) => ({
-      settings: {
+      userSettings: {
         isAdDetect: true,
         isReturnChannel: false,
         adRedirectChannelId: null,
       },
 
-      setSettings: (settings) =>
+      setUserSettings: (userSettings) =>
         set((state) => ({
-          settings: {
-            ...state.settings,
-            ...settings,
+          userSettings: {
+            ...state.userSettings,
+            ...userSettings,
           },
         })),
     }),


### PR DESCRIPTION
### ✨ 이슈 번호

- #162

### 📌 설명

- `Zustand` 상태 업데이트 함수들의 `set` 호출 방식을 일관되게 통일합니다.
- 예: `setPrevChannelId: (channelId) => set({ prevChannelId: channelId })` 형태를
`setPrevChannelId: (prevChannelId) => set({ prevChannelId })`로 변경합니다.
- 상태 `setter` 함수들의 파라미터명을 상태명과 동일하게 통일합니다
- `Zustand` 스타일을 통일하여 작성한 Pull Request입니다.

### 📃 작업 사항

- [x] `set({ key: value })` 형태를 `set({ key })`로 단순화
- [x] 상태 `setter` 함수들의 파라미터명을 상태명과 동일하게 통일

### 💭 리뷰 사항 반영

### ✅ Pull Request 체크 사항

- [x] 가장 최신 브랜치를 pull 하였습니다.
- [x] base 브랜치명을 확인하였습니다.
- [x] 코드 컨벤션을 모두 확인하였습니다.
- [x] 브랜치명을 확인하였습니다.
